### PR TITLE
Fix config URL encoding

### DIFF
--- a/.serena/.gitignore
+++ b/.serena/.gitignore
@@ -1,0 +1,2 @@
+/cache
+/project.local.yml

--- a/.serena/memories/api/core.md
+++ b/.serena/memories/api/core.md
@@ -1,0 +1,4 @@
+- `apps/api` is the Cloudflare Worker/Hono app.
+- `packages/api-handlers` contains reusable API handler logic.
+- Web build output is copied into `apps/api/public` during build.
+- API-related changes should stay in the API package or shared packages, not the web app.

--- a/.serena/memories/conventions.md
+++ b/.serena/memories/conventions.md
@@ -1,0 +1,5 @@
+- Keep TypeScript strict and explicit; avoid `any`.
+- Use React Context for app-wide state, React Query for server state, and React Hook Form for forms.
+- Keep shared logic in `packages/shared`; keep web-only UI in `apps/web`.
+- Match existing component naming: PascalCase components, camelCase functions/variables.
+- Prefer minimal edits that stay within the existing file/module unless a broader change is required.

--- a/.serena/memories/core.md
+++ b/.serena/memories/core.md
@@ -1,0 +1,5 @@
+- Monorepo with `apps/web` SPA, `apps/api` Cloudflare Worker, and shared packages under `packages/*`.
+- Web app is route-driven React; API handlers are separate from shared logic.
+- Module map lives in `mem:web/core`, `mem:api/core`, and `mem:shared/core`.
+- Repo-wide conventions and verification live in `mem:tech_stack`, `mem:conventions`, `mem:suggested_commands`, and `mem:task_completion`.
+- Keep changes surgical; respect existing module boundaries.

--- a/.serena/memories/memory_maintenance.md
+++ b/.serena/memories/memory_maintenance.md
@@ -1,0 +1,33 @@
+# Memory Maintenance
+
+## Discovery Model
+
+- Core principle: progressive discovery through references, building a graph of memories.
+- Initially, agents are provided with the list of all memories (names only).
+- Agents should read `mem:core` as the top-level entry point (graph root).
+  This memory should contain references to other memories covering major project domains.
+  The referenced memories shall, in turn, shall contain references to even more specific memories, and so on.
+  The depth of the graph shall depend on the project complexity.
+- Use topics/folders to group related memories in order to make the content structure explicit.
+  Folders can mirror project structure (e.g. modules like frontend/backend) or topics like debugging, architecture, etc.
+- Memory references must use a mem: prefix inside backticks, e.g. `mem:frontend/core`.
+  The surrounding text should clearly indicate when to read the memory/which content to expect.
+  The text should provide more precise guidance than the memory name alone, 
+  i.e. avoid a reference like "frontend debugging: `mem:frontend/debugging` and instead make clear which aspects of frontend debugging are covered.
+- Memories themselves should not contain information about when to read them; this is the responsibility of the referring memory.
+
+## Style
+
+Dense agent notes, not prose docs. Prefer invariants, terse bullets. 
+Avoid obvious context, rationale, and examples unless they prevent likely mistakes. 
+Keep guidance durable and generalizable, not task-local.
+
+## Add/update threshold
+
+Add or update memories only with stable, non-obvious project conventions that avoid complex rediscovery in the future.
+Do not add: quick-read facts; generic language/framework knowledge; one-off task notes; volatile line-level details; behavior likely to change soon.
+
+## Maintenance Actions
+
+- Renaming memories: References are updated automatically if handled via Serena's memory rename tool.
+- Checking for stale memories (e.g. after deletion): Call `serena memories check` for a report.

--- a/.serena/memories/shared/core.md
+++ b/.serena/memories/shared/core.md
@@ -1,0 +1,3 @@
+- `packages/shared` holds cross-cutting business logic: classes, constants, enums, types, validators, and utilities.
+- Shared code is consumed by both the web app and API packages.
+- Prefer placing reusable domain logic here instead of duplicating it in app packages.

--- a/.serena/memories/suggested_commands.md
+++ b/.serena/memories/suggested_commands.md
@@ -1,0 +1,7 @@
+- `npm run dev` - run the workspace dev servers.
+- `npm run build` - full repo build via Turbo.
+- `npm run check-types` - full repo typecheck via Turbo.
+- `npm run lint` - full repo lint via Turbo.
+- `npm run test` - run Vitest.
+- `npm -w apps/web run build` - build the web app and emit to `apps/api/public`.
+- `npm -w apps/web run check-types` - typecheck the web app only.

--- a/.serena/memories/task_completion.md
+++ b/.serena/memories/task_completion.md
@@ -1,0 +1,4 @@
+- For web app changes, run `npm -w apps/web run build`.
+- For broader verification, run `npm run build`, `npm run check-types`, and `npm run test` as needed.
+- If touching tests, run the relevant Vitest target before finishing.
+- If you need to verify the onboarding cache, run `serena memories check` from the project root.

--- a/.serena/memories/tech_stack.md
+++ b/.serena/memories/tech_stack.md
@@ -1,0 +1,5 @@
+- TypeScript strict mode across the repo.
+- React 19, React Router 7, TanStack React Query 5, React Hook Form 7, Zod, HeroUI v3, Tailwind CSS v4.
+- Vite powers the web build; Cloudflare Workers + Hono power the API.
+- Package manager is npm workspaces (`npm@11`).
+- Tests use Vitest; E2E lives under `packages/e2e`.

--- a/.serena/memories/web/core.md
+++ b/.serena/memories/web/core.md
@@ -1,0 +1,5 @@
+- `apps/web` is the React SPA.
+- Uses React Router, React Query, React Hook Form, Tailwind CSS v4, and HeroUI v3-era component styling.
+- App state lives in React Context under `apps/web/src/contexts/`.
+- Route pages are under `apps/web/src/pages/`; reusable UI lives under `apps/web/src/components/`.
+- Build path emits to `apps/api/public`.

--- a/.serena/project.yml
+++ b/.serena/project.yml
@@ -1,0 +1,133 @@
+# the name by which the project can be referenced within Serena
+project_name: "wheel-in-the-sky-3"
+
+
+# list of languages for which language servers are started; choose from:
+#   al                  angular             ansible             bash                clojure
+#   cpp                 cpp_ccls            crystal             csharp              csharp_omnisharp
+#   dart                elixir              elm                 erlang              fortran
+#   fsharp              go                  groovy              haskell             haxe
+#   hlsl                html                java                json                julia
+#   kotlin              lean4               lua                 luau                markdown
+#   matlab              msl                 nix                 ocaml               pascal
+#   perl                php                 php_phpactor        powershell          python
+#   python_jedi         python_ty           r                   rego                ruby
+#   ruby_solargraph     rust                scala               scss                solidity
+#   svelte              swift               systemverilog       terraform           toml
+#   typescript          typescript_vts      vue                 yaml                zig
+#   (This list may be outdated. For the current list, see values of Language enum here:
+#   https://github.com/oraios/serena/blob/main/src/solidlsp/ls_config.py
+#   For some languages, there are alternative language servers, e.g. csharp_omnisharp, ruby_solargraph.)
+# Note:
+#   - For C, use cpp
+#   - For JavaScript, use typescript
+#   - For Angular projects, use angular (subsumes typescript+html; requires `npm install` in the project root)
+#   - For Svelte projects, use svelte (subsumes typescript/javascript for .svelte projects; requires npm)
+#   - For SCSS / Sass / plain CSS, use scss (some-sass-language-server handles all three)
+#   - For Free Pascal/Lazarus, use pascal
+# Special requirements:
+#   Some languages require additional setup/installations.
+#   See here for details: https://oraios.github.io/serena/01-about/020_programming-languages.html#language-servers
+# When using multiple languages, the first language server that supports a given file will be used for that file.
+# The first language is the default language and the respective language server will be used as a fallback.
+# Note that when using the JetBrains backend, language servers are not used and this list is correspondingly ignored.
+languages:
+- typescript
+
+# the encoding used by text files in the project
+# For a list of possible encodings, see https://docs.python.org/3.11/library/codecs.html#standard-encodings
+encoding: "utf-8"
+
+# line ending convention to use when writing source files.
+# Possible values: unset (use global setting), "lf", "crlf", or "native" (platform default)
+# This does not affect Serena's own files (e.g. memories and configuration files), which always use native line endings.
+line_ending:
+
+# The language backend to use for this project.
+# If not set, the global setting from serena_config.yml is used.
+# Valid values: LSP, JetBrains
+# Note: the backend is fixed at startup. If a project with a different backend
+# is activated post-init, an error will be returned.
+language_backend:
+
+# whether to use project's .gitignore files to ignore files
+ignore_all_files_in_gitignore: true
+
+# advanced configuration option allowing to configure language server-specific options.
+# Maps the language key to the options.
+# Have a look at the docstring of the constructors of the LS implementations within solidlsp (e.g., for C# or PHP) to see which options are available.
+# No documentation on options means no options are available.
+ls_specific_settings: {}
+
+# list of additional workspace folder paths for cross-package reference support (e.g. in monorepos).
+# Paths can be absolute or relative to the project root.
+# Each folder is registered as an LSP workspace folder, enabling language servers to discover
+# symbols and references across package boundaries.
+# Currently supported for: TypeScript.
+# Example:
+#   additional_workspace_folders:
+#     - ../sibling-package
+#     - ../shared-lib
+additional_workspace_folders: []
+
+# list of additional paths to ignore in this project.
+# Same syntax as gitignore, so you can use * and **.
+# Note: global ignored_paths from serena_config.yml are also applied additively.
+ignored_paths: []
+
+# whether the project is in read-only mode
+# If set to true, all editing tools will be disabled and attempts to use them will result in an error
+# Added on 2025-04-18
+read_only: false
+
+# list of tool names to exclude.
+# This extends the existing exclusions (e.g. from the global configuration)
+# Find the list of tools here: https://oraios.github.io/serena/01-about/035_tools.html
+excluded_tools: []
+
+# list of tools to include that would otherwise be disabled (particularly optional tools that are disabled by default).
+# This extends the existing inclusions (e.g. from the global configuration).
+# Find the list of tools here: https://oraios.github.io/serena/01-about/035_tools.html
+included_optional_tools: []
+
+# fixed set of tools to use as the base tool set (if non-empty), replacing Serena's default set of tools.
+# This cannot be combined with non-empty excluded_tools or included_optional_tools.
+# Find the list of tools here: https://oraios.github.io/serena/01-about/035_tools.html
+fixed_tools: []
+
+# list of mode names that are to be activated by default, overriding the setting in the global configuration.
+# The full set of modes to be activated is base_modes (from global config) + default_modes + added_modes.
+# If the setting is undefined/empty, the default_modes from the global configuration (serena_config.yml) apply.
+# Otherwise, this overrides the setting from the global configuration (serena_config.yml).
+# Therefore, you can set this to [] if you do not want the default modes defined in the global config to apply
+# for this project.
+# This setting can, in turn, be overridden by CLI parameters (--mode).
+# See https://oraios.github.io/serena/02-usage/050_configuration.html#modes
+default_modes:
+
+# list of mode names to be activated additionally for this project, e.g. ["query-projects"]
+# The full set of modes to be activated is base_modes (from global config) + default_modes + added_modes.
+# See https://oraios.github.io/serena/02-usage/050_configuration.html#modes
+added_modes:
+
+# initial prompt for the project. It will always be given to the LLM upon activating the project
+# (contrary to the memories, which are loaded on demand).
+initial_prompt: ""
+
+# time budget (seconds) per tool call for the retrieval of additional symbol information
+# such as docstrings or parameter information.
+# This overrides the corresponding setting in the global configuration; see the documentation there.
+# If null or missing, use the setting from the global configuration.
+symbol_info_budget:
+
+# list of regex patterns which, when matched, mark a memory entry as read‑only.
+# Extends the list from the global configuration, merging the two lists.
+read_only_memory_patterns: []
+
+# list of regex patterns for memories to completely ignore.
+# Matching memories will not appear in list_memories or activate_project output
+# and cannot be accessed via read_memory or write_memory.
+# To access ignored memory files, use the read_file tool on the raw file path.
+# Extends the list from the global configuration, merging the two lists.
+# Example: ["_archive/.*", "_episodes/.*"]
+ignored_memory_patterns: []

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ Complete rewrite (again). Version 3 has migrated from NextJS and is now an SPA u
 
 - Greensock, which ~~is~~ _was_ closed source (and expensive), is no longer used to handle the spinning.
 - App sounds have been removed. They were difficult to support across browser implementations, and were often buggy. They may return in the future, no promises.
+- Older version 3 share links (`/wheel/v3/:id` and `/config/v3/:id`) are no longer supported. Re-create and re-share affected wheels using the new `?c=` links.
 
 ### Security
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ Complete rewrite (again). Version 3 has migrated from NextJS and is now an SPA u
 
 ### Changed
 
+- Wheel configuration share links now use a versioned `?c=` query parameter with URL-safe encoding.
 - Wheel no longer "floats" to the center of the segment. It will stop where it stops.
 - Wheel is now individual DOM elements instead of a gradient. This helps ensure consistency across browsers.
 - Spinning is handled by custom-written code.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -117,6 +117,67 @@ All project-specific information is in the `docs/` directory. Reference these fi
 ✅ Respects monorepo structure
 ✅ Compliant with AGPL-3.0 principles
 
+# Tool selection (read this before every tool call on a code file)
+
+This project uses Serena, an MCP server that exposes semantic, symbol-aware tools
+for reading and editing code. Serena's tools are the PRIMARY tools for code work
+in this project. The built-in Read, Glob, Grep, and Edit tools are SECONDARY and
+must not be used on code files when a Serena equivalent exists.
+
+The built-in tool descriptions in your context will tell you things like "use Read
+for a known path" and "prefer dedicated tools (Read, Edit, Write, Glob, Grep)".
+Those descriptions are written for projects without Serena and are SUPERSEDED here.
+When they conflict with this section, this section wins. Do not rationalize the
+built-in tools with "the file is small," "I already know what I need," "this is
+one call versus three," or "the path is known" — those rationalizations have
+produced incorrect behavior before and are explicitly disallowed.
+
+## Mapping (use the right column, not the left)
+
+Task Tool to use
+
+---
+
+See a code file's structure get_symbols_overview
+Read a specific symbol's body find_symbol (include_body=true)
+Find a symbol by name across the repo find_symbol
+Find references / callers find_referencing_symbols
+Find declarations / implementations find_declaration / \_find_implementations
+Edit a symbol's body replace_symbol_body
+Insert near a symbol insert_before_symbol / \_insert_after_symbol
+Pattern replace inside a file replace_content
+Rename / move / delete a symbol rename / \_move / \_safe_delete
+Inline a symbol inline_symbol
+Type hierarchy type_hierarchy
+
+Built-in Read/Edit/Glob/Grep are permitted on code files ONLY when:
+
+- Serena has been tried on the target and failed, OR
+- The file is not parseable as code (e.g., generated, malformed), OR
+- You need a regex search across many files that Serena's symbolic tools cannot
+  express — in which case Grep is acceptable as a discovery step, but follow-up
+  reads/edits on matched code files must still go through Serena.
+- You need to read a few lines and symbolic reads would be an overkill.
+- You absolutely have to read the full file for some reason.
+
+Read/Edit/Glob are fine for non-code files: markdown, JSON, YAML, TOML, .env,
+config files, lockfiles, plain text, images.
+
+## Required workflow before editing code
+
+1. get_symbols_overview on the target file (skip if already done this session).
+2. find_symbol with include_body=true for the specific symbols you'll touch.
+   Read only the symbols you need — not the whole file.
+3. Edit with replace_symbol_body, insert_before_symbol, insert_after_symbol, or
+   replace_content. Never use the built-in Edit on a code file when one of these
+   fits.
+
+## Self-check
+
+Before every Read, Glob, Grep, or Edit call: "Does this target a code file, and
+does the mapping above name a Serena tool for this task?" If yes, switch. Do this
+check every time — not just once per session.
+
 ---
 
 **Remember**: Reference `docs/` directory for detailed implementation guidance. This file contains only core behavioral rules.

--- a/apps/web/src/components/action-accordion.tsx
+++ b/apps/web/src/components/action-accordion.tsx
@@ -16,7 +16,7 @@ export function ActionAccordion({ pathname, closeDrawer }: ActionAccordionProps)
                 <SavedWheelsList closeDrawer={closeDrawer} />
             </AccordionItem>
             <AccordionItem key="removed-winners" aria-label="Removed Winners" title="Removed Winners">
-                {isPage(pathname, PageBaseRoute.WheelV3) ? <RemovedWinnersList closeDrawer={closeDrawer} /> : null}
+                {isPage(pathname, PageBaseRoute.Wheel) ? <RemovedWinnersList closeDrawer={closeDrawer} /> : null}
             </AccordionItem>
         </Accordion>
     );

--- a/apps/web/src/components/navbar.tsx
+++ b/apps/web/src/components/navbar.tsx
@@ -17,16 +17,19 @@ import {
 } from '@heroui/react';
 import { useCallback, useMemo, useState } from 'react';
 import { FaList } from 'react-icons/fa6';
-import { useLocation, useParams } from 'react-router';
+import { useLocation, useSearchParams } from 'react-router';
 import { PageBaseRoute } from '@/constants/routes';
 import { isPage } from '@/utils/routes';
 import { ActionAccordion } from './action-accordion';
 
 export function AppNavBar() {
     const { pathname } = useLocation();
-    const params = useParams();
-    const configId = params?.id ?? 'new';
-    const uriEncodedConfigId = useMemo(() => encodeURIComponent(configId), [configId]);
+    const [searchParams] = useSearchParams();
+    const currentEncodedConfig = searchParams.get('c');
+    const configQuery = useMemo(
+        () => (currentEncodedConfig ? `?c=${currentEncodedConfig}` : ''),
+        [currentEncodedConfig]
+    );
 
     const [isMenuOpen, setIsMenuOpen] = useState(false);
     const { isOpen: isDrawerOpen, onOpen: onDrawerOpen, onOpenChange: onDrawerOpenChange } = useDisclosure();
@@ -39,26 +42,26 @@ export function AppNavBar() {
         (Component: typeof NavbarItem | typeof NavbarMenuItem) => {
             return (
                 <>
-                    {configId !== 'new' && (
-                        <Component isActive={isPage(pathname, PageBaseRoute.WheelV3)}>
+                    {currentEncodedConfig && (
+                        <Component isActive={isPage(pathname, PageBaseRoute.Wheel)}>
                             <Link
                                 color="foreground"
-                                aria-current={isPage(pathname, PageBaseRoute.WheelV3) ? 'page' : 'false'}
-                                href={`/wheel/v3/${uriEncodedConfigId}`}
+                                aria-current={isPage(pathname, PageBaseRoute.Wheel) ? 'page' : 'false'}
+                                href={`${PageBaseRoute.Wheel}${configQuery}`}
                                 onPress={closeMenu}
                             >
                                 Wheel
                             </Link>
                         </Component>
                     )}
-                    <Component isActive={isPage(pathname, PageBaseRoute.ConfigV3)}>
+                    <Component isActive={isPage(pathname, PageBaseRoute.Config)}>
                         <Link
                             color="foreground"
-                            aria-current={isPage(pathname, PageBaseRoute.ConfigV3) ? 'page' : 'false'}
-                            href={`/config/v3/${uriEncodedConfigId}`}
+                            aria-current={isPage(pathname, PageBaseRoute.Config) ? 'page' : 'false'}
+                            href={`${PageBaseRoute.Config}${configQuery}`}
                             onPress={closeMenu}
                         >
-                            {configId === 'new' ? 'Create Wheel' : 'Change Wheel'}
+                            {currentEncodedConfig ? 'Change Wheel' : 'Create Wheel'}
                         </Link>
                     </Component>
                     <Component isActive={isPage(pathname, PageBaseRoute.About)}>
@@ -74,7 +77,7 @@ export function AppNavBar() {
                 </>
             );
         },
-        [configId, uriEncodedConfigId, pathname, closeMenu]
+        [currentEncodedConfig, configQuery, pathname, closeMenu]
     );
 
     const navbarItems = useMemo(() => {

--- a/apps/web/src/components/saved-wheels-list.tsx
+++ b/apps/web/src/components/saved-wheels-list.tsx
@@ -5,6 +5,7 @@ import { MdSave } from 'react-icons/md';
 import { MdDeleteForever } from 'react-icons/md';
 import { MdOutlinePlayCircleFilled } from 'react-icons/md';
 import { useNavigate } from 'react-router';
+import { PageBaseRoute } from '@/constants/routes';
 import { useConfig } from '@/contexts/config';
 import { useSegment } from '@/contexts/segment';
 import { dateIsWithinLast5Minutes } from '@/utils/dates';
@@ -66,7 +67,7 @@ export function SavedWheelsList({ closeDrawer }: SavedWheelsListProps) {
                                 color="primary"
                                 onPress={() => {
                                     setHasWinner(false);
-                                    navigate(`/wheel/v3/${encodeURIComponent(wheel.encodedConfig)}`);
+                                    navigate(`${PageBaseRoute.Wheel}?c=${wheel.encodedConfig}`);
                                     closeDrawer?.();
                                 }}
                                 className="text-2xl"

--- a/apps/web/src/constants/routes.ts
+++ b/apps/web/src/constants/routes.ts
@@ -1,6 +1,6 @@
 export enum PageBaseRoute {
     Home = '/',
     About = '/about',
-    WheelV3 = '/wheel/v3',
-    ConfigV3 = '/config/v3',
+    Wheel = '/wheel',
+    Config = '/config',
 }

--- a/apps/web/src/hooks/config.ts
+++ b/apps/web/src/hooks/config.ts
@@ -27,6 +27,7 @@ export function useDecodedConfig(encodedConfig?: string): UseQueryResult<Config 
 
             return newConfig;
         },
+        enabled: typeof encodedConfig === 'string',
         retry: 1,
         staleTime: 1000 * 60 * 15,
     });

--- a/apps/web/src/hooks/config.ts
+++ b/apps/web/src/hooks/config.ts
@@ -1,8 +1,6 @@
 import { Config } from '@repo/shared/classes/config';
 import { ConfigFormInputs } from '@repo/shared/types/config';
 import { type UseQueryResult, useMutation, useQuery } from '@tanstack/react-query';
-import { useEffect } from 'react';
-import { useNavigate } from 'react-router';
 import { api } from '@/utils/api';
 
 export function useDecodedConfig(encodedConfig?: string): UseQueryResult<Config | undefined> {
@@ -48,14 +46,4 @@ export function useEncodeConfigMutation() {
         },
         retry: 1,
     });
-}
-
-export function useValidConfigCheck(id: string | undefined, isError: boolean) {
-    const navigate = useNavigate();
-
-    useEffect(() => {
-        if (id === undefined || isError) {
-            navigate('/config/v3/new');
-        }
-    }, [id, isError, navigate]);
 }

--- a/apps/web/src/pages/config-page.tsx
+++ b/apps/web/src/pages/config-page.tsx
@@ -24,12 +24,12 @@ import { useCallback, useEffect, useMemo, useState } from 'react';
 import { FormProvider, SubmitHandler, useForm, useWatch } from 'react-hook-form';
 import { FaAngleDown, FaAngleUp } from 'react-icons/fa6';
 import { MdClear, MdOutlineAddCircle, MdSave } from 'react-icons/md';
-import { useNavigate, useParams } from 'react-router';
+import { useNavigate, useSearchParams } from 'react-router';
 import { ColorPicker } from '@/components/color-picker';
 import { WheelPreview } from '@/components/wheel-preview';
 import { PageBaseRoute } from '@/constants/routes';
 import { useSetDocumentBackgroundColor, useSetDocumentForegroundColor } from '@/hooks/colors';
-import { useDecodedConfig, useEncodeConfigMutation, useValidConfigCheck } from '@/hooks/config';
+import { useDecodedConfig, useEncodeConfigMutation } from '@/hooks/config';
 
 function getDefaultFormValues(config: Config | undefined): ConfigFormInputs {
     return {
@@ -49,12 +49,11 @@ function getDefaultFormValues(config: Config | undefined): ConfigFormInputs {
 }
 
 export default function ConfigPage() {
-    const { id } = useParams();
+    const [searchParams] = useSearchParams();
+    const requestedConfig = searchParams.get('c') ?? 'new';
     const navigate = useNavigate();
 
-    const { data: config, isError, isPending } = useDecodedConfig(id);
-
-    useValidConfigCheck(id, isError);
+    const { data: config, isError, isPending } = useDecodedConfig(requestedConfig);
 
     const defaultFormValues = useMemo(() => {
         return getDefaultFormValues(config);
@@ -117,7 +116,7 @@ export default function ConfigPage() {
         async (data) => {
             const { encodedConfig } = await encodeConfig(data);
             if (encodedConfig) {
-                navigate(`/wheel/v3/${encodedConfig}`);
+                navigate(`${PageBaseRoute.Wheel}?c=${encodedConfig}`);
             }
         },
         [encodeConfig, navigate]
@@ -145,7 +144,7 @@ export default function ConfigPage() {
                         <p className="mb-4">The configuration could not be loaded. Please try creating a new wheel.</p>
                     </CardBody>
                     <CardFooter className="flex justify-center">
-                        <Button color="primary" variant="flat" onPress={() => navigate('/config/v3/new')}>
+                        <Button color="primary" variant="flat" onPress={() => navigate(PageBaseRoute.Config)}>
                             Create New Wheel
                         </Button>
                     </CardFooter>
@@ -371,7 +370,7 @@ export default function ConfigPage() {
                                     {isLoaded ? (
                                         <div className="flex justify-between">
                                             <div className="flex gap-4">
-                                                {id !== 'new' && (
+                                                {requestedConfig !== 'new' && (
                                                     <Button
                                                         className="text-base"
                                                         startContent={<MdSave className="text-2xl" />}
@@ -385,8 +384,8 @@ export default function ConfigPage() {
                                                 <Button
                                                     className="text-base"
                                                     startContent={<MdOutlineAddCircle className="text-2xl" />}
-                                                    color={id === 'new' ? 'primary' : 'secondary'}
-                                                    variant={id === 'new' ? 'solid' : 'flat'}
+                                                    color={requestedConfig === 'new' ? 'primary' : 'secondary'}
+                                                    variant={requestedConfig === 'new' ? 'solid' : 'flat'}
                                                     title="If you have saved this wheel, this button will create a new wheel and not overwrite the saved wheel"
                                                     onPress={() => {
                                                         methods.setValue('id', Config.generateId());
@@ -398,7 +397,7 @@ export default function ConfigPage() {
                                             </div>
                                             <Button
                                                 as={Link}
-                                                href={`${PageBaseRoute.ConfigV3}/new`}
+                                                href={PageBaseRoute.Config}
                                                 className="text-base"
                                                 startContent={<MdClear className="text-2xl" />}
                                                 color="danger"

--- a/apps/web/src/pages/home-page.tsx
+++ b/apps/web/src/pages/home-page.tsx
@@ -18,7 +18,7 @@ export default function HomePage() {
                     Whether you&apos;re planning a raffle, need a creative way to choose teams, or want to settle
                     debates, Wheel in the Sky makes it effortless and entertaining.
                 </p>
-                <Button as={Link} href="/config/v3/new" className="mt-8" size="lg" color="primary" variant="shadow">
+                <Button as={Link} href="/config" className="mt-8" size="lg" color="primary" variant="shadow">
                     Make a Wheel
                 </Button>
             </div>

--- a/apps/web/src/pages/home-page.tsx
+++ b/apps/web/src/pages/home-page.tsx
@@ -1,5 +1,6 @@
 import { Button, Divider, Link } from '@heroui/react';
 import { defaultPageColorConfig } from '@repo/shared/constants/colors';
+import { PageBaseRoute } from '@/constants/routes';
 import { useSetDocumentBackgroundColor, useSetDocumentForegroundColor } from '@/hooks/colors';
 
 export default function HomePage() {
@@ -18,7 +19,14 @@ export default function HomePage() {
                     Whether you&apos;re planning a raffle, need a creative way to choose teams, or want to settle
                     debates, Wheel in the Sky makes it effortless and entertaining.
                 </p>
-                <Button as={Link} href="/config" className="mt-8" size="lg" color="primary" variant="shadow">
+                <Button
+                    as={Link}
+                    href={PageBaseRoute.Config}
+                    className="mt-8"
+                    size="lg"
+                    color="primary"
+                    variant="shadow"
+                >
                     Make a Wheel
                 </Button>
             </div>

--- a/apps/web/src/pages/legacy-page.tsx
+++ b/apps/web/src/pages/legacy-page.tsx
@@ -6,6 +6,7 @@ import { useNavigate, useParams } from 'react-router';
 import { Encoder } from '@/compatibility/v2/classes/encoder';
 import { ConfigV2QueryParams } from '@/compatibility/v2/types';
 import { convertConfigV2ToConfigV3 } from '@/compatibility/v2/utils';
+import { PageBaseRoute } from '@/constants/routes';
 import { useSetDocumentBackgroundColor, useSetDocumentForegroundColor } from '@/hooks/colors';
 import { useEncodeConfigMutation } from '@/hooks/config';
 
@@ -46,7 +47,7 @@ export default function LegacyPage() {
                 </p>
                 <Button
                     as={Link}
-                    href={`/wheel/v3/${newConfig}`}
+                    href={newConfig ? `${PageBaseRoute.Wheel}?c=${newConfig}` : PageBaseRoute.Wheel}
                     className="mt-8"
                     size="lg"
                     color="primary"

--- a/apps/web/src/pages/wheel-page.tsx
+++ b/apps/web/src/pages/wheel-page.tsx
@@ -7,9 +7,10 @@ import { RefObject, useEffect, useMemo, useRef } from 'react';
 import { FaChevronDown } from 'react-icons/fa6';
 import { IoRemoveCircleOutline } from 'react-icons/io5';
 import { LuClipboardCopy } from 'react-icons/lu';
-import { useNavigate, useParams } from 'react-router';
+import { useNavigate, useSearchParams } from 'react-router';
 import { Banner } from '@/components/banner';
 import { Wheel } from '@/components/wheel';
+import { PageBaseRoute } from '@/constants/routes';
 import { useConfig } from '@/contexts/config';
 import { useRemovedWinners } from '@/contexts/removed-winners';
 import { useRotation } from '@/contexts/rotation';
@@ -32,33 +33,36 @@ function getBanner(bannerRef: RefObject<HTMLCanvasElement | null>) {
 
 export default function WheelPage() {
     const navigate = useNavigate();
-    const { id } = useParams();
+    const [searchParams] = useSearchParams();
+    const encodedConfig = searchParams.get('c') ?? undefined;
     const { setDecodedConfig, setEncodedConfig } = useConfig();
     const { updateWheelIfSaved } = useSavedWheels();
 
-    if (id === undefined || id === 'new') {
-        navigate('/config/v3/new');
-    }
+    useEffect(() => {
+        if (encodedConfig === undefined) {
+            navigate(PageBaseRoute.Config);
+        }
+    }, [encodedConfig, navigate]);
 
     const { rotation, setRotation } = useRotation();
     const { segment, setSegment, hasWinner, setHasWinner } = useSegment();
     const { removedWinners, setRemovedWinners } = useRemovedWinners();
 
-    const { data: decodedConfig, isError, isPending } = useDecodedConfig(id);
+    const { data: decodedConfig, isError, isPending } = useDecodedConfig(encodedConfig);
 
     useEffect(() => {
-        updateWheelIfSaved(decodedConfig, id);
-    }, [decodedConfig, id, updateWheelIfSaved]);
+        updateWheelIfSaved(decodedConfig, encodedConfig);
+    }, [decodedConfig, encodedConfig, updateWheelIfSaved]);
 
     useEffect(() => {
-        if (decodedConfig !== undefined && id !== undefined && id !== 'new') {
+        if (decodedConfig !== undefined && encodedConfig !== undefined) {
             setDecodedConfig(decodedConfig);
-            setEncodedConfig(id);
+            setEncodedConfig(encodedConfig);
         } else {
             setDecodedConfig(undefined);
             setEncodedConfig(undefined);
         }
-    }, [setDecodedConfig, setEncodedConfig, decodedConfig, id]);
+    }, [setDecodedConfig, setEncodedConfig, decodedConfig, encodedConfig]);
 
     // Optimization: Create stable string representation of removedWinners array contents
     // to prevent unnecessary WheelManager recreation when array reference changes.
@@ -143,7 +147,7 @@ export default function WheelPage() {
                         <p className="mb-4">Please check your configuration and try again.</p>
                     </CardBody>
                     <CardFooter className="flex justify-center">
-                        <Button color="primary" variant="flat" onPress={() => navigate('/config/v3/new')}>
+                        <Button color="primary" variant="flat" onPress={() => navigate(PageBaseRoute.Config)}>
                             Go to Configuration
                         </Button>
                     </CardFooter>
@@ -163,7 +167,7 @@ export default function WheelPage() {
                         <p className="mb-4">Please add at least one segment to the wheel.</p>
                     </CardBody>
                     <CardFooter className="flex justify-center">
-                        <Button color="primary" variant="flat" onPress={() => navigate('/config/v3/new')}>
+                        <Button color="primary" variant="flat" onPress={() => navigate(PageBaseRoute.Config)}>
                             Add Segments
                         </Button>
                     </CardFooter>

--- a/apps/web/src/routes.tsx
+++ b/apps/web/src/routes.tsx
@@ -14,8 +14,8 @@ export function Router() {
         <Routes>
             <Route path="/" element={<RootLayout />}>
                 <Route index element={<HomePage />} />
-                <Route path="wheel/v3/:id?" element={<WheelPage />} />
-                <Route path="config/v3/:id?" element={<ConfigPage />} />
+                <Route path="wheel" element={<WheelPage />} />
+                <Route path="config" element={<ConfigPage />} />
                 <Route path="about" element={<AboutPage />} />
                 <Route path="404" element={<NotFoundPage />} />
                 <Route path=":oldId" element={<LegacyPage />} />

--- a/apps/web/src/utils/__tests__/routes.test.ts
+++ b/apps/web/src/utils/__tests__/routes.test.ts
@@ -5,7 +5,7 @@ import { isPage } from '@/utils/routes';
 describe('isPage', () => {
     it('should return false for empty pathname', () => {
         expect(isPage('', PageBaseRoute.Home)).toBe(false);
-        expect(isPage('', PageBaseRoute.ConfigV3)).toBe(false);
+        expect(isPage('', PageBaseRoute.Config)).toBe(false);
     });
 
     it('should match home page exactly', () => {
@@ -15,20 +15,20 @@ describe('isPage', () => {
     });
 
     it('should match other pages by prefix', () => {
-        expect(isPage('/config/v3', PageBaseRoute.ConfigV3)).toBe(true);
-        expect(isPage('/config/v3/123', PageBaseRoute.ConfigV3)).toBe(true);
-        expect(isPage('/wheel/v3', PageBaseRoute.WheelV3)).toBe(true);
-        expect(isPage('/wheel/v3/abc', PageBaseRoute.WheelV3)).toBe(true);
+        expect(isPage('/config', PageBaseRoute.Config)).toBe(true);
+        expect(isPage('/config?c=v4.abc', PageBaseRoute.Config)).toBe(true);
+        expect(isPage('/wheel', PageBaseRoute.Wheel)).toBe(true);
+        expect(isPage('/wheel?c=v4.abc', PageBaseRoute.Wheel)).toBe(true);
     });
 
     it('should return false for non-matching routes', () => {
-        expect(isPage('/something', PageBaseRoute.ConfigV3)).toBe(false);
-        expect(isPage('/wheels', PageBaseRoute.WheelV3)).toBe(false);
-        expect(isPage('/configurations', PageBaseRoute.ConfigV3)).toBe(false);
+        expect(isPage('/something', PageBaseRoute.Config)).toBe(false);
+        expect(isPage('/wheels', PageBaseRoute.Wheel)).toBe(false);
+        expect(isPage('/configurations', PageBaseRoute.Config)).toBe(false);
     });
 
     it('should handle invalid pathnames', () => {
         expect(isPage('invalid', PageBaseRoute.Home)).toBe(false);
-        expect(isPage('invalid/path', PageBaseRoute.ConfigV3)).toBe(false);
+        expect(isPage('invalid/path', PageBaseRoute.Config)).toBe(false);
     });
 });

--- a/apps/web/src/utils/routes.ts
+++ b/apps/web/src/utils/routes.ts
@@ -8,5 +8,5 @@ export function isPage(pathname: string, page: PageBaseRoute): boolean {
     if (page === PageBaseRoute.Home) {
         return pathname === page;
     }
-    return pathname.startsWith(page);
+    return pathname === page || pathname.startsWith(`${page}/`) || pathname.startsWith(`${page}?`);
 }

--- a/packages/api-handlers/src/server/__tests__/encoding.test.ts
+++ b/packages/api-handlers/src/server/__tests__/encoding.test.ts
@@ -45,7 +45,7 @@ describe('encodingApi', () => {
 
     describe('POST /encode', () => {
         it('should encode config from form data and return encoded result', async () => {
-            vi.mocked(encodeConfig).mockResolvedValue('encoded-config-string');
+            vi.mocked(encodeConfig).mockResolvedValue('v4.encoded-config-string');
 
             const response = await encodingApi.request('/encode', {
                 method: 'POST',
@@ -57,13 +57,13 @@ describe('encodingApi', () => {
             const responseData = await response.json();
 
             expect(response.status).toBe(200);
-            expect(responseData).toEqual({ encodedConfig: 'encoded-config-string' });
+            expect(responseData).toEqual({ encodedConfig: 'v4.encoded-config-string' });
             expect(encodeConfig).toHaveBeenCalled();
         });
 
         it('should handle single color background', async () => {
             mockFormData.backgroundColorType = PageColorType.Single.toString();
-            vi.mocked(encodeConfig).mockResolvedValue('encoded-config-string');
+            vi.mocked(encodeConfig).mockResolvedValue('v4.encoded-config-string');
 
             const response = await encodingApi.request('/encode', {
                 method: 'POST',
@@ -75,7 +75,7 @@ describe('encodingApi', () => {
             const responseData = await response.json();
 
             expect(response.status).toBe(200);
-            expect(responseData).toEqual({ encodedConfig: 'encoded-config-string' });
+            expect(responseData).toEqual({ encodedConfig: 'v4.encoded-config-string' });
             expect(encodeConfig).toHaveBeenCalled();
         });
 
@@ -100,7 +100,7 @@ describe('encodingApi', () => {
     describe('POST /decode', () => {
         it('should decode an encoded config string and return the resulting object', async () => {
             const mockRequestData = {
-                encodedConfig: 'encoded-config-string',
+                encodedConfig: 'v4.encoded-config-string',
             };
             const mockDecodedConfig = new Config();
 
@@ -117,7 +117,7 @@ describe('encodingApi', () => {
 
             expect(response.status).toBe(200);
             expect(responseData).toEqual(mockDecodedConfig);
-            expect(decodeConfig).toHaveBeenCalledWith('encoded-config-string');
+            expect(decodeConfig).toHaveBeenCalledWith('v4.encoded-config-string');
         });
 
         it('should handle errors during decoding', async () => {

--- a/packages/api-handlers/src/utils/__tests__/encoding.test.ts
+++ b/packages/api-handlers/src/utils/__tests__/encoding.test.ts
@@ -16,22 +16,29 @@ beforeEach(() => {
 });
 
 describe('encodeConfig', () => {
-    it('should encode a SerializedConfigManager object to a base64 string', async () => {
+    it('should encode a SerializedConfigManager object to a v4 base64url string', async () => {
         const encoded = await encodeConfig(input);
         expect(typeof encoded).toBe('string');
-        expect(encoded).toMatch(/%[0-9A-F]{2}/i); // Check if the string is URL-encoded
+        expect(encoded).toMatch(/^v4\.[A-Za-z0-9_-]+$/);
+        expect(encoded).not.toContain('%');
+        expect(encoded).not.toContain('+');
+        expect(encoded).not.toContain('/');
+        expect(encoded).not.toContain('=');
     });
 });
 
 describe('decodeConfig', () => {
-    it('should decode a base64 string to a SerializedConfigManager object', async () => {
+    it('should decode a v4 base64url string to a SerializedConfigManager object', async () => {
         const encoded = await encodeConfig(input);
         const decoded = await decodeConfig(encoded);
         expect(decoded).toEqual(input);
     });
 
-    it('should throw an error for invalid base64 string', async () => {
-        const invalidBase64 = 'invalid_base64_string';
-        await expect(decodeConfig(invalidBase64)).rejects.toThrow();
+    it('should throw an error for unsupported encoding versions', async () => {
+        await expect(decodeConfig('v3.invalid_base64_string')).rejects.toThrow('Invalid config');
+    });
+
+    it('should throw an error for invalid v4 payloads', async () => {
+        await expect(decodeConfig('v4.invalid_base64_string')).rejects.toThrow('Invalid config');
     });
 });

--- a/packages/api-handlers/src/utils/__tests__/encoding.test.ts
+++ b/packages/api-handlers/src/utils/__tests__/encoding.test.ts
@@ -42,3 +42,47 @@ describe('decodeConfig', () => {
         await expect(decodeConfig('v4.invalid_base64_string')).rejects.toThrow('Invalid config');
     });
 });
+
+describe('base64url payload edge cases', () => {
+    it('round-trips configs of varying sizes, covering all base64 padding cases', async () => {
+        const paddingRemainders = new Set<number>();
+
+        for (let i = 0; i <= 40; i++) {
+            const config = new Config();
+            config.setTitle('T'.repeat(i));
+            config.setNames(Array.from({ length: i }, (_, n) => `Name ${n}`).join('\n'));
+            const serialized = config.serialize();
+
+            const encoded = await encodeConfig(serialized);
+            const body = encoded.slice('v4.'.length);
+            paddingRemainders.add(body.length % 4);
+
+            expect(encoded).not.toContain('+');
+            expect(encoded).not.toContain('/');
+            expect(encoded).not.toContain('=');
+
+            const decoded = await decodeConfig(encoded);
+            expect(decoded).toEqual(serialized);
+        }
+
+        // A base64 body length is always a multiple of 4. Stripping 0, 1, or 2 '=' padding
+        // chars leaves a remainder of 0, 3, or 2 respectively. Confirm all are exercised so the
+        // padding restoration in fromBase64Url is covered for every case.
+        expect(paddingRemainders).toEqual(new Set([0, 2, 3]));
+    });
+
+    it('round-trips values containing URL-unsafe characters', async () => {
+        const config = new Config();
+        config.setTitle('a+b/c=d & é 日本語 <>?#');
+        config.setDescription('special: +/= %20\nline breaks\ttabs');
+        config.setNames('+++\n///\n===\n%%%');
+        const serialized = config.serialize();
+
+        const encoded = await encodeConfig(serialized);
+        expect(encoded).toMatch(/^v4\.[A-Za-z0-9_-]+$/);
+        expect(encoded).not.toContain('%');
+
+        const decoded = await decodeConfig(encoded);
+        expect(decoded).toEqual(serialized);
+    });
+});

--- a/packages/api-handlers/src/utils/encoding.ts
+++ b/packages/api-handlers/src/utils/encoding.ts
@@ -1,31 +1,46 @@
 import { SerializedConfigManager } from '@repo/shared/types/config';
 
+const CONFIG_ENCODING_VERSION = 'v4.';
+
 /**
- * Compresses and encodes the input object to a base64 string.
+ * Compresses and encodes the input object to a versioned base64url string.
  *
  * @param {SerializedConfigManager} input - The input object to be encoded.
- * @returns {Promise<string>} The compressed and encoded base64 string.
+ * @returns {Promise<string>} The compressed and encoded base64url string.
  */
 export async function encodeConfig(input: SerializedConfigManager): Promise<string> {
     const compressedBuffer = await compressWithGzip(JSON.stringify(input));
-    return encodeURIComponent(compressedBuffer);
+    return `${CONFIG_ENCODING_VERSION}${toBase64Url(compressedBuffer)}`;
 }
 
 /**
- * Decodes and decompresses the input base64 string to an object.
+ * Decodes and decompresses the input versioned base64url string to an object.
  *
- * @param {string} input - The base64 string to be decoded.
+ * @param {string} input - The versioned base64url string to be decoded.
  * @returns {Promise<SerializedConfigManager>} The decoded and decompressed object.
  * @throws {Error} If the input string is invalid.
  */
 export async function decodeConfig(input: string): Promise<SerializedConfigManager> {
     try {
-        const decodedInput = decodeURIComponent(input);
+        if (!input.startsWith(CONFIG_ENCODING_VERSION)) {
+            throw new Error('Unsupported config encoding version');
+        }
+
+        const decodedInput = fromBase64Url(input.slice(CONFIG_ENCODING_VERSION.length));
         const decompressedText = await decompressFromGzip(decodedInput);
         return JSON.parse(decompressedText);
     } catch (error) {
         throw new Error('Invalid config', { cause: error });
     }
+}
+
+function toBase64Url(input: string): string {
+    return input.replaceAll('+', '-').replaceAll('/', '_').replaceAll('=', '');
+}
+
+function fromBase64Url(input: string): string {
+    const base64 = input.replaceAll('-', '+').replaceAll('_', '/');
+    return base64.padEnd(base64.length + ((4 - (base64.length % 4)) % 4), '=');
 }
 
 /**


### PR DESCRIPTION
## Summary
- Replace path-segment wheel config links with versioned `?c=` query-param links.
- Encode wheel configs as `v4.` gzip-compressed base64url payloads.
- Update web navigation/routes, saved wheel links, tests, and changelog for the new share URL format.

## Test Plan
- [x] `npm run test`

## Notes
- This PR also includes the existing `aef0ae8 agent memory updates` commit already present on this branch.