### PR TITLE
chore: upgrade Sentry to 10.70.0 and adopt @sentry/hono

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -19,7 +19,7 @@
     "@heroui/theme": "2.4.26",
     "@repo/api-handlers": "*",
     "@repo/shared": "*",
-    "@sentry/react": "10.39.0",
+    "@sentry/react": "10.70.0",
     "@tanstack/react-query": "5.90.21",
     "@uidotdev/usehooks": "2.4.1",
     "canvas-confetti": "1.9.4",
@@ -38,7 +38,7 @@
   },
   "devDependencies": {
     "@fontsource-variable/quicksand": "5.2.10",
-    "@sentry/vite-plugin": "5.0.0",
+    "@sentry/vite-plugin": "5.4.0",
     "@tailwindcss/vite": "4.2.1",
     "@testing-library/jest-dom": "6.9.1",
     "@testing-library/react": "16.3.2",

--- a/docs/superpowers/plans/2026-08-11-sentry-upgrade.md
+++ b/docs/superpowers/plans/2026-08-11-sentry-upgrade.md
@@ -1,0 +1,392 @@
+# Sentry 10.70.0 Upgrade Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Move every Sentry package from 10.39.0 to 10.70.0 and replace the deprecated `honoIntegration` code path with `@sentry/hono`, without changing observable application behavior.
+
+**Architecture:** Two commits on branch `chore/sentry-upgrade-10.70`. Commit 1 is a pure dependency bump requiring no TypeScript changes. Commit 2 rewrites the Sentry wiring in one file, `packages/api-handlers/src/server/index.ts`, moving from a `withSentry` wrapper around the Hono app to a `sentry()` middleware registered on it. Splitting them keeps a clean revert target, because the two halves carry different risk.
+
+**Tech Stack:** npm workspaces, Turborepo, Hono 4.12.2, Cloudflare Workers via Wrangler 4.68.0, Vitest 4.0.18, TypeScript strict.
+
+**Spec:** `docs/superpowers/specs/2026-08-11-sentry-upgrade-design.md`
+
+## A note on TDD for this plan
+
+This plan does not follow a red-green-refactor cycle, and that is deliberate rather than an oversight. There is no new behavior to test-drive: the spec's explicit intent is that observable behavior stays the same, and research against the published 10.70.0 tarballs confirmed that every API this repository calls is unchanged. Writing a test that fails before a version number changes and passes after would be theater.
+
+The discipline is preserved differently. Each task starts by **establishing a green baseline before touching anything**, so that any breakage is unambiguously attributable to the change rather than to pre-existing state. Each task ends with the same verification suite re-run. That baseline-then-reverify gate is the functional equivalent of the red-green cycle for a dependency upgrade.
+
+Existing tests are expected to pass unmodified throughout. If any test needs editing to pass, **stop and report it**, because that means the upgrade changed behavior the spec claimed it would not.
+
+## Global Constraints
+
+- Target version for `@sentry/react`, `@sentry/cloudflare`, and `@sentry/hono` is exactly `10.70.0`. `@sentry/hono` declares `@sentry/cloudflare` as an exact-version peer, so these cannot drift apart.
+- Target version for `@sentry/vite-plugin` is exactly `5.4.0`. Target for `@sentry/cli` is exactly `3.6.2`.
+- All installs run **from the repository root** targeting a workspace with `--save-exact`. Never `cd` into a workspace to install. This is a documented monorepo rule.
+- Both `@sentry/cli` copies (`packages/api-handlers` and `packages/shared`) must move together, or `npm run sherif` fails on cross-workspace version inconsistency. `sherif` runs in the pre-commit hook.
+- `@sentry/cli` stays in `dependencies`, not `devDependencies`, in both packages. It is arguably misplaced, but that is pre-existing and out of scope.
+- Do **not** change `apps/api/wrangler.jsonc` `compatibility_flags`. It stays `["nodejs_als"]`. The spec explains why.
+- Do **not** add a `CHANGELOG.md` entry. An SDK version bump is not a user-facing change under the project's changelog policy.
+- Filenames are kebab-case. TypeScript is strict, no `any`.
+- Import ordering is applied automatically by `@trivago/prettier-plugin-sort-imports`. Do not hand-order imports.
+
+## Critical execution notes
+
+**`npm run test` is watch mode.** The root `test` script is bare `vitest`, which never exits. For every verification step in this plan use `npm run test:ci` (`vitest run --coverage`). Running `npm run test` in an automated context will hang.
+
+**Build must precede test.** Two documented traps combine here. First, `packages/api-handlers` and `apps/api` define no `check-types` script, so `npm run check-types` skips them entirely and their type errors surface only at build time. Second, the test suites resolve `@repo/api-handlers/server` to built output in `dist`, and Vitest runs outside Turbo, so a stale `dist` makes a passing test run meaningless. Always `npm run build` before `npm run test:ci`.
+
+**The working tree carries pre-existing uncommitted changes.** `apps/api/wrangler.jsonc` (observability config) and the root `package.json` `allowScripts` block were carried onto this branch from `main` and are intentionally uncommitted. Commit 1 builds on top of that `allowScripts` block. Stage files by name; never `git add -A`.
+
+## File structure
+
+| File | Responsibility | Task |
+| --- | --- | --- |
+| `apps/web/package.json` | `@sentry/react` and `@sentry/vite-plugin` version pins | 1 |
+| `packages/api-handlers/package.json` | `@sentry/cloudflare`, `@sentry/cli`, then `@sentry/hono` pins | 1, 2 |
+| `packages/shared/package.json` | `@sentry/cli` version pin | 1 |
+| `package.json` (root) | `allowScripts` keys permitting `@sentry/cli` install scripts | 1 |
+| `package-lock.json` | resolved dependency graph | 1, 2 |
+| `packages/api-handlers/src/server/index.ts` | Hono app construction and Sentry wiring | 2 |
+
+Files explicitly **not** modified: `apps/api/src/index.ts` (the `export default app` remains valid because `HonoBase` satisfies `ExportedHandler<Env>`), `apps/web/src/main.tsx`, `apps/web/vite.config.ts`, `packages/api-handlers/src/client/index.ts`, and every existing test file.
+
+---
+
+### Task 1: Dependency bump
+
+**Files:**
+- Modify: `apps/web/package.json` (`dependencies["@sentry/react"]`, `devDependencies["@sentry/vite-plugin"]`)
+- Modify: `packages/api-handlers/package.json` (`dependencies["@sentry/cloudflare"]`, `dependencies["@sentry/cli"]`)
+- Modify: `packages/shared/package.json` (`dependencies["@sentry/cli"]`)
+- Modify: `package.json` (root, `allowScripts` block)
+- Modify: `package-lock.json`
+- Test: no new tests; existing suites must pass unmodified
+
+**Interfaces:**
+- Consumes: nothing.
+- Produces: `@sentry/cloudflare` at exactly `10.70.0` in `packages/api-handlers`, which Task 2 requires because `@sentry/hono@10.70.0` declares it as an exact-version peer.
+
+- [ ] **Step 1: Confirm branch and establish a green baseline**
+
+Verify you are on the right branch and that everything passes *before* any change. If the baseline is red, stop and report rather than proceeding, because you will not be able to attribute later failures.
+
+```bash
+git branch --show-current   # expect: chore/sentry-upgrade-10.70
+npm run build
+npm run test:ci
+```
+
+Expected: build succeeds, all tests pass.
+
+- [ ] **Step 2: Record the current resolved `@sentry/cli` versions**
+
+You need this to know which `allowScripts` keys change. Save the output somewhere you can compare against after the install.
+
+```bash
+node -e "const l=require('./package-lock.json'); for(const [k,v] of Object.entries(l.packages)) if(k.includes('@sentry/cli')&&v.version) console.log(k, v.version)"
+```
+
+Expected: entries showing `2.58.5` (transitive, under `@sentry/vite-plugin`) and `3.2.2` (direct).
+
+- [ ] **Step 3: Run the five installs**
+
+Each is pinned exact and targets a workspace from the root.
+
+```bash
+npm install --save-exact --workspace apps/web @sentry/react@10.70.0
+npm install --save-exact --workspace apps/web --save-dev @sentry/vite-plugin@5.4.0
+npm install --save-exact --workspace packages/api-handlers @sentry/cloudflare@10.70.0
+npm install --save-exact --workspace packages/api-handlers @sentry/cli@3.6.2
+npm install --save-exact --workspace packages/shared @sentry/cli@3.6.2
+```
+
+- [ ] **Step 4: Read the newly resolved `@sentry/cli` versions**
+
+Run the same command as Step 2. The transitive version is a caret resolution (`@sentry/bundler-plugins@10.70.0` depends on `@sentry/cli@^2.58.6`), so it must be **read, not assumed**.
+
+```bash
+node -e "const l=require('./package-lock.json'); for(const [k,v] of Object.entries(l.packages)) if(k.includes('@sentry/cli')&&v.version) console.log(k, v.version)"
+```
+
+Expected: a direct `3.6.2`, and a transitive version at or above `2.58.6`. Note the exact transitive value for Step 5.
+
+- [ ] **Step 5: Update the root `allowScripts` block**
+
+Edit `package.json`, replacing the two stale keys with the versions you just read. If Step 4 reported a transitive version other than `2.58.6`, use that instead.
+
+```diff
+   "allowScripts": {
+     "@heroui/shared-utils@2.1.12": true,
+-    "@sentry/cli@2.58.5": true,
+-    "@sentry/cli@3.2.2": true,
++    "@sentry/cli@2.58.6": true,
++    "@sentry/cli@3.6.2": true,
+     "esbuild@0.27.3": true,
+```
+
+A stale key fails silently: it does not error, it just stops the package's install scripts from running, which for `@sentry/cli` means the platform binary is never downloaded.
+
+- [ ] **Step 6: Reinstall and confirm the `sentry-cli` binary actually works**
+
+This is the check that proves Step 5 was correct. `@sentry/cli` fetches a platform binary in a postinstall script; if `allowScripts` does not permit it, the package installs but the binary is missing.
+
+```bash
+rm -rf node_modules
+npm install
+npx --workspace packages/api-handlers sentry-cli --version
+```
+
+Expected: prints `sentry-cli 3.6.2`. If it errors about a missing binary, the `allowScripts` key is wrong.
+
+- [ ] **Step 7: Verify dependency consistency**
+
+```bash
+npm run sherif
+```
+
+Expected: `✓ No issues found`. A failure here almost certainly means the two `@sentry/cli` copies disagree.
+
+- [ ] **Step 8: Build, typecheck, lint**
+
+Build first, for the reasons in "Critical execution notes".
+
+```bash
+npm run build
+npm run check-types
+npm run lint
+```
+
+Expected: all succeed with no errors.
+
+- [ ] **Step 9: Run the full test suite**
+
+```bash
+npm run test:ci
+```
+
+Expected: all tests pass, **unmodified**. If any test requires editing, stop and report: that contradicts the spec's claim that this bump is behavior-neutral.
+
+- [ ] **Step 10: Commit**
+
+Stage by name. The `apps/api/wrangler.jsonc` change is pre-existing and intentionally excluded here.
+
+```bash
+git add package.json package-lock.json apps/web/package.json packages/api-handlers/package.json packages/shared/package.json
+git commit -m "chore: upgrade Sentry packages to 10.70.0
+
+@sentry/react and @sentry/cloudflare 10.39.0 to 10.70.0,
+@sentry/vite-plugin 5.0.0 to 5.4.0, @sentry/cli 3.2.2 to 3.6.2.
+
+No API changes were required. Updates the allowScripts keys, which
+pin exact @sentry/cli versions, including the transitive copy that
+moved when @sentry/vite-plugin restructured onto @sentry/bundler-plugins."
+```
+
+---
+
+### Task 2: Adopt `@sentry/hono`
+
+**Files:**
+- Modify: `packages/api-handlers/package.json` (add `dependencies["@sentry/hono"]`)
+- Modify: `packages/api-handlers/src/server/index.ts` (full Sentry wiring rewrite, currently lines 1 and 31-38)
+- Modify: `package-lock.json`
+- Test: no new tests; existing suites must pass unmodified, plus manual Worker probes
+
+**Interfaces:**
+- Consumes: `@sentry/cloudflare@10.70.0` from Task 1, required as an exact-version peer.
+- Produces: `export const app` changes static type from `ExportedHandler<Env, unknown, unknown>` to `HonoBase<AppEnv, BlankSchema, '/api', '/api'>`. Both satisfy `ExportedHandler<Env>`, so `apps/api/src/index.ts` needs no change. `export const routes` keeps a byte-identical type, so `hc<ApiAppType>` in `apps/web/src/utils/api.ts` is unaffected.
+
+- [ ] **Step 1: Install `@sentry/hono`**
+
+`@sentry/cloudflare` stays a dependency. `@sentry/hono/cloudflare` re-exports it wholesale and pins it as an exact-version peer.
+
+```bash
+npm install --save-exact --workspace packages/api-handlers @sentry/hono@10.70.0
+```
+
+- [ ] **Step 2: Confirm the peer resolved cleanly**
+
+```bash
+npm ls @sentry/hono @sentry/cloudflare --workspace packages/api-handlers
+```
+
+Expected: both at `10.70.0`, with no `UNMET PEER DEPENDENCY` warnings.
+
+- [ ] **Step 3: Rewrite the Sentry wiring**
+
+Replace the entire contents of `packages/api-handlers/src/server/index.ts` with the following. Three things change: the import on line 1, the addition of the `sentry()` middleware as the **first** `.use()`, and the `app` export at the bottom. The `cors()` config, `notFound` handler, and `routes` export are byte-for-byte unchanged.
+
+```typescript
+import { sentry } from '@sentry/hono/cloudflare';
+import { Hono } from 'hono';
+import { env } from 'hono/adapter';
+import { cors } from 'hono/cors';
+import { encodingApi } from '@/server/encoding.js';
+import { AppEnv } from '@/types.js';
+
+const honoApp = new Hono<AppEnv>().basePath('/api');
+
+honoApp.use(
+    sentry(honoApp, (sentryEnv) => ({
+        dsn: 'https://895c486a1e653f07201b20658156b954@o4508580787781632.ingest.us.sentry.io/4509040320970752',
+        tracesSampleRate: 1.0,
+        enabled: sentryEnv.APP_ENV !== 'local',
+    }))
+);
+
+honoApp.use(
+    '*',
+    cors({
+        origin: (origin, c) => {
+            const { APP_ENV } = env(c);
+            return APP_ENV === 'local' || origin.endsWith('wheel-in-the-sky.bri-9c5.workers.dev') ? origin : undefined;
+        },
+        allowMethods: ['POST', 'GET'],
+        allowHeaders: ['Content-Type', 'Accept-Encoding', 'sentry-trace', 'baggage'],
+        exposeHeaders: ['Content-Length'],
+        maxAge: 86400,
+    })
+);
+
+honoApp.notFound((c) => {
+    const { ASSETS } = env(c);
+    return ASSETS.fetch(c.req.url);
+});
+
+export const routes = honoApp.route('/config', encodingApi);
+
+export const app = honoApp;
+```
+
+Three constraints are load-bearing and must not be "tidied":
+
+1. `sentry()` is the **first** `.use()`, ahead of `cors()`. Its middleware runs a request handler before `await next()` and a response handler after, so it must be outermost to observe `context.error` and own root span naming.
+2. `sentry()` is registered **before** `.route()`. Handlers are wrapped at registration time, so anything mounted earlier gets no middleware span.
+3. `sentry()` receives `honoApp`, the `.basePath('/api')` result, because that is the instance actually exported and served.
+
+The explicit `withSentry<Env>` generic is gone: `sentryEnv` now infers as `Env` from `AppEnv['Bindings']`. Do not add a generic back.
+
+Do not add a `shouldHandleError` option. Its default already matches current effective behavior, since `@sentry/cloudflare` already ships `honoIntegration()` by default and that integration already ignores 3xx and 4xx.
+
+- [ ] **Step 4: Verify dependency consistency, build, typecheck, lint**
+
+The build is the only real typecheck for this package, since it has no `check-types` script.
+
+```bash
+npm run sherif
+npm run build
+npm run check-types
+npm run lint
+```
+
+Expected: all succeed. A type error on `export default app` in `apps/api/src/index.ts` would mean the `ExportedHandler` assignment assumption is wrong; stop and report.
+
+- [ ] **Step 5: Run the full test suite**
+
+```bash
+npm run test:ci
+```
+
+Expected: all tests pass unmodified. Note that `apps/api/src/__tests__/index.test.ts` asserts `app.routes` is a non-empty array, which now holds more directly than before, since `app` is the Hono instance itself rather than a wrapper.
+
+- [ ] **Step 6: Start the local Worker**
+
+Run from the repository root so Turbo builds `apps/web` into `apps/api/public` first. Leave this running in a background shell.
+
+```bash
+npm run dev
+```
+
+Wait until Wrangler reports the Worker is ready on `http://localhost:8787`.
+
+- [ ] **Step 7: Check the console for the ordering warning**
+
+Scan the dev server output. It must **not** contain:
+
+```
+[hono] N sub-app(s) were mounted before sentry()
+```
+
+If that warning appears, the `sentry()` registration is in the wrong position relative to `.route()`. Fix Step 3 before continuing.
+
+- [ ] **Step 8: Probe route resolution and handler execution**
+
+```bash
+curl -s -o /dev/null -w '%{http_code}\n' -X POST http://localhost:8787/api/config/decode \
+  -H 'Content-Type: application/json' -d '{"encodedConfig":"garbage"}'
+```
+
+Expected: `400`. This proves the request reached the `/decode` handler, `decodeConfig` threw, and the handler's own catch returned JSON. A `404` means routing broke; a `500` means the error escaped the handler.
+
+- [ ] **Step 9: Probe that validation still runs beneath `sentry()`**
+
+```bash
+curl -s -o /dev/null -w '%{http_code}\n' -X POST http://localhost:8787/api/config/decode \
+  -H 'Content-Type: application/json' -d '{}'
+```
+
+Expected: `400`, this time from `zValidator` rather than the handler body.
+
+- [ ] **Step 10: Probe CORS, the highest-risk check**
+
+This is the probe that matters most, because `sentry()` now precedes `cors()` in the middleware chain. `APP_ENV` is `local` per `apps/api/.dev.vars`, so the origin callback echoes any origin back.
+
+```bash
+curl -s -i -X OPTIONS http://localhost:8787/api/config/decode \
+  -H 'Origin: https://example.com' \
+  -H 'Access-Control-Request-Method: POST' | grep -i 'access-control-allow-origin'
+```
+
+Expected: a header line `access-control-allow-origin: https://example.com`. If this header is absent, the middleware reordering broke CORS and the change must not be committed.
+
+- [ ] **Step 11: Probe the notFound and ASSETS fallback**
+
+```bash
+curl -s -o /dev/null -w '%{http_code}\n' http://localhost:8787/api/nope
+```
+
+Expected: `200`, because `notFound` delegates to `ASSETS.fetch`, which serves the SPA shell. A `404` would mean the fallback broke.
+
+- [ ] **Step 12: Stop the dev server**
+
+Terminate the background `npm run dev` process.
+
+- [ ] **Step 13: Commit**
+
+```bash
+git add packages/api-handlers/package.json packages/api-handlers/src/server/index.ts package-lock.json
+git commit -m "refactor: replace withSentry with @sentry/hono middleware
+
+@sentry/cloudflare ships honoIntegration() as a default integration,
+which is deprecated as of 10.55.0 in favor of the @sentry/hono package.
+
+Registers sentry() as the first middleware, ahead of cors() and before
+route mounting, so it wraps handlers at registration time. Gains
+route-parametrized transaction names and middleware spans. The typed
+RPC contract exported as routes is unchanged."
+```
+
+---
+
+## Verification gaps to report at handoff
+
+These are known and accepted per the spec, not defects to fix. Whoever finishes this work should state plainly that they were not verified:
+
+- **Sentry event delivery was not verified.** `apps/api/.dev.vars` sets `APP_ENV=local` and the config is `enabled: sentryEnv.APP_ENV !== 'local'`, so the SDK is switched off under `wrangler dev`. The probes prove the application works with the middleware installed, not that events arrive.
+- **Route-parametrized transaction names were not verified.** That is the primary benefit of adopting `@sentry/hono`, and it is only observable in the Sentry UI after a deploy.
+- **Source map upload with `@sentry/cli` 3.6.2 was not verified.** It runs only under `build:with-sentry`, which needs `SENTRY_AUTH_TOKEN`.
+- **The `@sentry/vite-plugin` 5.4.0 internal restructure was not exercised.** The plugin is gated behind `WITH_SENTRY`, so the default build path never loads it.
+
+## Expected behavior changes, not defects
+
+Do not "fix" these if you notice them. They follow from the version bump and were accepted in the spec:
+
+- Session and crash-free-user metrics will shift. 10.40.0 fixed session accounting so user id is consistently attached and the first soft navigation after pageload is no longer skipped. Alerts keyed to those metrics may fire.
+- Bot traffic stops producing transactions. 10.44.0 skips `browserTracingIntegration` setup for bot user agents.
+- The Worker bundle grows by roughly 7 KB minified, 2.7 KB gzipped, from `@sentry/hono`.
+- React routing spans gain `url.template`, `url.path`, and `url.full` attributes as of 10.65.0.
+
+## Rollback
+
+One `git revert` per commit. Reverting Task 2's commit restores `withSentry` while leaving the version bump in place. Reverting both returns to 10.39.0.

--- a/docs/superpowers/specs/2026-08-11-sentry-upgrade-design.md
+++ b/docs/superpowers/specs/2026-08-11-sentry-upgrade-design.md
@@ -1,0 +1,284 @@
+# Sentry Upgrade to 10.70.0 and `@sentry/hono` Adoption
+
+Date: 2026-08-11
+Branch: `chore/sentry-upgrade-10.70`
+
+## Context
+
+The repository runs Sentry JavaScript SDK 10.39.0 in both the browser
+(`@sentry/react`) and the Cloudflare Worker (`@sentry/cloudflare`). The request
+that prompted this work cited the Sentry Cloudflare migration guide, whose
+newest entry is v9 to v10. That migration has already been applied, so no
+breaking migration guide is outstanding.
+
+Latest stable across the Sentry packages is 10.70.0. An `11.0.0-alpha.0` exists
+but has no published migration guide, and `docs.sentry.io` returns 404 for a
+v10-to-v11 page. v11 is therefore out of scope.
+
+Research against the published 10.70.0 tarballs and the `sentry-javascript`
+source at tag `10.70.0` established that the 10.39.0 to 10.70.0 bump requires
+no code changes: every `init` option in use, and the `withSentry` signature,
+are unchanged and undeprecated across the intervening 31 minor releases.
+
+The optional improvement available is `@sentry/hono`, stable since 10.55.0,
+which supersedes the now-deprecated `honoIntegration` that `@sentry/cloudflare`
+currently enables by default.
+
+## Goals
+
+1. Move every Sentry package to its latest stable version.
+2. Replace the deprecated `honoIntegration` code path with `@sentry/hono`,
+   gaining route-parametrized transaction names and middleware spans.
+3. Keep the change verifiable locally and revertible in isolated pieces.
+
+## Non-goals
+
+- Upgrading to v11 or any prerelease.
+- Flipping `compatibility_flags` from `nodejs_als` to `nodejs_compat`. See
+  "Deferred work" for why this was considered and rejected.
+- Adopting the `@sentry/cloudflare/nodejs_compat` entrypoint. It adds only
+  Prisma and Vercel AI integrations, neither of which this project uses.
+- The `apps/web/src/components/error-boundary.tsx:43` TODO about wiring the
+  React error boundary into Sentry.
+- Moving `@sentry/cli` from `dependencies` to `devDependencies` in
+  `packages/api-handlers` and `packages/shared`. It is arguably misplaced for a
+  build-time tool, but that is pre-existing and unrelated.
+
+## Current integration surface
+
+| Location                                       | What it does                                                  |
+| ---------------------------------------------- | ------------------------------------------------------------- |
+| `apps/web/src/main.tsx:9`                      | `sentryInit` with browser tracing and replay integrations     |
+| `packages/api-handlers/src/server/index.ts:31` | `withSentry<Env>(optionsCallback, honoApp)`                   |
+| `apps/web/vite.config.ts:18`                   | `sentryVitePlugin`, gated behind the `WITH_SENTRY` env var    |
+| `packages/api-handlers/package.json`           | `sentry:sourcemaps` script calling `sentry-cli`               |
+| `packages/shared/package.json`                 | `sentry:sourcemaps` script calling `sentry-cli`               |
+| `.github/workflows/reusable-sentry-operations.yaml` | `sentry-cli releases new` and `releases finalize`        |
+| `package.json` `allowScripts`                  | pins exact `@sentry/cli` versions permitted to run installs   |
+
+## Design
+
+The work lands as two commits on one branch. The two halves have different risk
+profiles: the version bump is mechanical and needs no source changes, while the
+middleware adoption changes evaluation order relative to `cors()`. Splitting
+them means a failure during local verification identifies its own cause, and
+the middleware change can be reverted without giving up the version bump.
+
+### Commit 1: dependency bump
+
+Five installs, run from the repository root, pinned exact per the monorepo
+convention:
+
+```bash
+npm install --save-exact --workspace apps/web @sentry/react@10.70.0
+npm install --save-exact --workspace apps/web --save-dev @sentry/vite-plugin@5.4.0
+npm install --save-exact --workspace packages/api-handlers @sentry/cloudflare@10.70.0
+npm install --save-exact --workspace packages/api-handlers @sentry/cli@3.6.2
+npm install --save-exact --workspace packages/shared @sentry/cli@3.6.2
+```
+
+Both `@sentry/cli` copies must move together or `npm run sherif`, which runs in
+the pre-commit hook, fails on version inconsistency across workspaces.
+
+Then one hand edit to the root `package.json` `allowScripts` block:
+
+```diff
+-    "@sentry/cli@2.58.5": true,
+-    "@sentry/cli@3.2.2": true,
++    "@sentry/cli@2.58.6": true,
++    "@sentry/cli@3.6.2": true,
+```
+
+The `2.58.6` value above is illustrative, not authoritative. That key is
+transitive: `@sentry/vite-plugin@5.4.0` restructured its internals from
+`@sentry/bundler-plugin-core` to `@sentry/bundler-plugins@10.70.0`, which
+depends on `@sentry/cli@^2.58.6`. Because that is a caret range, the exact key
+must be read out of `package-lock.json` after install and whatever is actually
+resolved must be used. A stale key does not error loudly; it silently stops the
+package's install scripts from running.
+
+No TypeScript source files change in this commit. The only edits are workspace
+`package.json` version fields, the root `allowScripts` block, and the lockfile.
+
+### Commit 2: `@sentry/hono` adoption
+
+One install:
+
+```bash
+npm install --save-exact --workspace packages/api-handlers @sentry/hono@10.70.0
+```
+
+`@sentry/cloudflare` remains a dependency. It is an optional peer of
+`@sentry/hono` pinned to the exact version `10.70.0`, and
+`@sentry/hono/cloudflare` re-exports it wholesale. This is why both packages
+must sit at the same version, which Commit 1 establishes.
+
+`packages/api-handlers/src/server/index.ts` becomes:
+
+```typescript
+import { sentry } from '@sentry/hono/cloudflare';
+import { Hono } from 'hono';
+import { env } from 'hono/adapter';
+import { cors } from 'hono/cors';
+import { encodingApi } from '@/server/encoding.js';
+import { AppEnv } from '@/types.js';
+
+const honoApp = new Hono<AppEnv>().basePath('/api');
+
+honoApp.use(
+    sentry(honoApp, (sentryEnv) => ({
+        dsn: 'https://895c486a1e653f07201b20658156b954@o4508580787781632.ingest.us.sentry.io/4509040320970752',
+        tracesSampleRate: 1.0,
+        enabled: sentryEnv.APP_ENV !== 'local',
+    }))
+);
+
+honoApp.use('*', cors({ /* unchanged */ }));
+
+honoApp.notFound((c) => {
+    const { ASSETS } = env(c);
+    return ASSETS.fetch(c.req.url);
+});
+
+export const routes = honoApp.route('/config', encodingApi);
+
+export const app = honoApp;
+```
+
+Four properties of this shape were verified rather than assumed:
+
+**Middleware ordering is load-bearing.** `sentry()` must be the first `.use()`,
+ahead of `cors()`. Its returned middleware runs a request handler before
+`await next()` and a response handler after, so it must be outermost to observe
+`context.error` and to own root span naming. It must also be registered before
+`.route()`: `applyPatches` wraps handlers at registration time, so anything
+mounted earlier gets no middleware span, and the SDK logs a warning about
+sub-apps mounted before `sentry()`.
+
+**`sentry()` returns a middleware, not a wrapped app.** It calls `withSentry`
+internally and discards the return value, relying on in-place mutation of the
+Hono instance. `export const app = honoApp` is therefore correct, and
+`export default app` in `apps/api/src/index.ts` needs no change because
+`HonoBase` satisfies `ExportedHandler<Env>`.
+
+**The typed RPC contract does not move.** Emitting declarations for the old and
+new shapes produces a byte-identical `typeof routes`, so `hc<ApiAppType>` in
+`apps/web/src/utils/api.ts` is unaffected. The explicit `withSentry<Env>`
+generic disappears because `sentryEnv` infers as `Env` from `AppEnv['Bindings']`.
+
+**Capture behavior is near-neutral.** `@sentry/cloudflare` already ships
+`honoIntegration()` as a default integration, and its `defaultShouldHandleError`
+already ignores 3xx and 4xx. `@sentry/hono` applies an equivalent default and
+strips the Cloudflare `Hono` integration to prevent double capture. No
+`shouldHandleError` override is configured, because the default already matches
+current effective behavior and an explicit override would be unrequested
+configuration.
+
+`app` and `routes` become the same object reference under two names with
+different static types, where today `app` is a distinct wrapper value. Both
+exports are retained because both are consumed by name: `app` by
+`apps/api/src/index.ts`, `routes` by the client contract.
+
+## Verification
+
+Local only. Run this sequence for each commit:
+
+```bash
+npm install
+npm run sherif
+npm run build
+npm run check-types
+npm run lint
+npm run test
+```
+
+Build must precede test, for two reasons documented in the workspace guides.
+`packages/api-handlers` and `apps/api` define no `check-types` script, so root
+`check-types` skips them and their type errors surface only at build time. And
+the test suites resolve `@repo/api-handlers/server` to built output while Vitest
+runs outside Turbo, so a stale `dist` makes a passing run meaningless.
+
+For Commit 2, additionally run `npm run dev` and probe the Worker:
+
+| Probe                                                        | Establishes                                             |
+| ------------------------------------------------------------ | ------------------------------------------------------- |
+| `POST /api/config/decode` with `{"encodedConfig":"garbage"}` | route resolution and handler execution survive          |
+| `POST /api/config/decode` with `{}`                          | `zValidator` still runs beneath `sentry()`              |
+| `OPTIONS /api/config/decode` with an `Origin` header         | `cors()` still functions now that `sentry()` precedes it |
+| `GET /api/nope`                                              | `notFound` and the `ASSETS` fallback are intact          |
+
+The CORS probe is the important one, since middleware reordering is the riskiest
+part of the change.
+
+The dev console must not contain `[hono] N sub-app(s) were mounted before
+sentry()`. That warning would indicate the registration order is wrong.
+
+Existing tests continue to pass unmodified. `apps/api/src/__tests__/index.test.ts`
+asserts `app.routes` is a non-empty array, which holds more directly once `app`
+is the Hono instance itself.
+
+### Known verification gaps
+
+`enabled: sentryEnv.APP_ENV !== 'local'` disables Sentry under `wrangler dev`.
+The probes above establish that the application still works with the middleware
+installed. They do not establish that events reach Sentry, that transaction
+names are now route-parametrized, or that `@sentry/cli` 3.6.2 still uploads
+source maps. Those surface only on deploy.
+
+Exercising the enabled path locally would require setting `APP_ENV` to a
+non-local value, which sends real events to the production Sentry project. That
+is not part of this plan.
+
+`@sentry/vite-plugin` is gated behind `WITH_SENTRY`, so its internal
+restructure is the change least covered by local verification.
+
+## Expected behavior changes
+
+These follow from the version bump and are not defects:
+
+- Session and crash-free-user metrics shift. 10.40.0 fixed session accounting so
+  user id is consistently attached and the first soft navigation after pageload
+  is no longer skipped. Alerts keyed to those metrics may fire.
+- Bot traffic stops producing transactions. 10.44.0 skips
+  `browserTracingIntegration` setup for bot user agents.
+- Worker bundle grows by roughly 7 KB minified, 2.7 KB gzipped, from
+  `@sentry/hono`.
+- React routing spans gain `url.template`, `url.path`, and `url.full`
+  attributes as of 10.65.0.
+
+## Rollback
+
+One `git revert` per commit. Reverting Commit 2 restores `withSentry` and leaves
+the version bump in place. Reverting both returns to 10.39.0.
+
+## Deferred work
+
+**`nodejs_compat`.** `apps/api/wrangler.jsonc` sets
+`compatibility_flags: ["nodejs_als"]`. Sentry v11 will require `nodejs_compat`
+instead. It is not required at 10.70.0: `@sentry/hono` has no `node:` imports
+and `@sentry/cloudflare` uses only `node:async_hooks`, which `nodejs_als`
+supplies.
+
+Flipping it now was considered and rejected. With `compatibility_date` at
+`2025-02-04`, `nodejs_compat` auto-activates `nodejs_compat_v2`, which injects
+`process` and `Buffer` globals into the Worker. Any transitive dependency that
+branches on `typeof process !== 'undefined'` would change behavior, and
+local-only verification cannot rule that out. The flag flip belongs with the v11
+upgrade, where it is mandatory and can be verified against a deploy.
+`no_nodejs_compat_v2` exists as an escape hatch if the injection proves to be
+the problem.
+
+**v11 upgrade.** Beyond the flag, the alpha migration notes list three items
+touching this integration: `browserTracingIntegration` stops capturing user
+timing spans by default, `replayIntegration` flips its session lifecycle default
+from `route` to `page`, and `sendDefaultPii` is replaced by `dataCollection`
+with a more permissive default. v11 also raises minimums to Node 20.19.0 and
+TypeScript 5.0.4. Revisit once a stable release and a published migration guide
+exist.
+
+## Working tree note
+
+`apps/api/wrangler.jsonc` (observability configuration) and the root
+`package.json` `allowScripts` block carried uncommitted changes from `main` onto
+this branch and will land alongside the Sentry work. The `allowScripts` edits in
+Commit 1 build on that uncommitted block.

--- a/package-lock.json
+++ b/package-lock.json
@@ -46,7 +46,7 @@
         "@heroui/theme": "2.4.26",
         "@repo/api-handlers": "*",
         "@repo/shared": "*",
-        "@sentry/react": "10.39.0",
+        "@sentry/react": "10.70.0",
         "@tanstack/react-query": "5.90.21",
         "@uidotdev/usehooks": "2.4.1",
         "canvas-confetti": "1.9.4",
@@ -65,7 +65,7 @@
       },
       "devDependencies": {
         "@fontsource-variable/quicksand": "5.2.10",
-        "@sentry/vite-plugin": "5.0.0",
+        "@sentry/vite-plugin": "5.4.0",
         "@tailwindcss/vite": "4.2.1",
         "@testing-library/jest-dom": "6.9.1",
         "@testing-library/react": "16.3.2",
@@ -97,6 +97,55 @@
       "integrity": "sha512-baYZExFpsdkBNuvGKTKWCwKH57HRZLVtycZS05WTQNVOiXVSeAki3nU35zlRbToeMW8aHlJfyS+1C4BOv27q0A==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@apm-js-collab/code-transformer": {
+      "version": "0.18.1",
+      "resolved": "https://registry.npmjs.org/@apm-js-collab/code-transformer/-/code-transformer-0.18.1.tgz",
+      "integrity": "sha512-u1Hb6bHjWtkSpiprwVP6YaHC1DTN4RAU3zYkUDUe7WMnJwdyU1pwTL9dFKiSJB9IiLue/EQovmyx6xhU7FFtAQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@types/estree": "^1.0.8",
+        "astring": "^1.9.0",
+        "esquery": "^1.7.0",
+        "meriyah": "^6.1.4",
+        "semifies": "^1.0.0",
+        "source-map": "^0.6.0"
+      },
+      "bin": {
+        "code-transformer": "cli.js"
+      }
+    },
+    "node_modules/@apm-js-collab/code-transformer-bundler-plugins": {
+      "version": "0.7.4",
+      "resolved": "https://registry.npmjs.org/@apm-js-collab/code-transformer-bundler-plugins/-/code-transformer-bundler-plugins-0.7.4.tgz",
+      "integrity": "sha512-nAfOeZPSUAQvJa1iFT/5oCrTm5YQhMMrfCNthNnaXHZiOQhu1KGuLoIx7HtbAi3wfwaBYLaICPIeenIaEwcXIg==",
+      "license": "MIT",
+      "dependencies": {
+        "@apm-js-collab/code-transformer": "^0.18.1",
+        "es-module-lexer": "^2.1.0",
+        "magic-string": "^0.30.21",
+        "module-details-from-path": "^1.0.4"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@apm-js-collab/code-transformer-bundler-plugins/node_modules/es-module-lexer": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.3.1.tgz",
+      "integrity": "sha512-shc1dbU90Yl/xq1QrC7QRtfcwURZuVRfPhZbDoldJ1cn1gzDvBaBWlv0eFolj5+0znnPJz5TXLxsN77X/12KTA==",
+      "license": "MIT"
+    },
+    "node_modules/@apm-js-collab/tracing-hooks": {
+      "version": "0.13.0",
+      "resolved": "https://registry.npmjs.org/@apm-js-collab/tracing-hooks/-/tracing-hooks-0.13.0.tgz",
+      "integrity": "sha512-mTvWz9rnQwx1U3h0XPTHaX7bgfkpipLLTQyjlC2cdhQpQEuoLT0AGzoydeoq2NxfEVv6fWOOETcSbb2nptleyw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@apm-js-collab/code-transformer": "^0.18.0",
+        "debug": "^4.4.1",
+        "module-details-from-path": "^1.0.4"
+      }
     },
     "node_modules/@asamuzakjp/css-color": {
       "version": "5.0.1",
@@ -497,7 +546,7 @@
       "version": "0.4.2",
       "resolved": "https://registry.npmjs.org/@cloudflare/kv-asset-handler/-/kv-asset-handler-0.4.2.tgz",
       "integrity": "sha512-SIOD2DxrRRwQ+jgzlXCqoEFiKOFqaPjhnNTGKXSRLvp1HiOvapLaFG2kEr9dYQTYe8rKrd9uvDUzmAITeNyaHQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT OR Apache-2.0",
       "engines": {
         "node": ">=18.0.0"
@@ -507,7 +556,7 @@
       "version": "2.14.0",
       "resolved": "https://registry.npmjs.org/@cloudflare/unenv-preset/-/unenv-preset-2.14.0.tgz",
       "integrity": "sha512-XKAkWhi1nBdNsSEoNG9nkcbyvfUrSjSf+VYVPfOto3gLTZVc3F4g6RASCMh6IixBKCG2yDgZKQIHGKtjcnLnKg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT OR Apache-2.0",
       "peerDependencies": {
         "unenv": "2.0.0-rc.24",
@@ -526,7 +575,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -543,7 +591,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -560,7 +607,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -577,7 +623,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -594,7 +639,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -608,7 +652,7 @@
       "version": "0.8.1",
       "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
       "integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/trace-mapping": "0.3.9"
@@ -621,7 +665,7 @@
       "version": "0.3.9",
       "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
       "integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.0.3",
@@ -773,7 +817,6 @@
       "version": "1.8.1",
       "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.8.1.tgz",
       "integrity": "sha512-mehfKSMWjjNol8659Z8KxEMrdSJDDot5SXMq00dM8BN4o+CLNXQ0xH2V7EchNHV4RmbZLmmPdEaXZc5H2FXmDg==",
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -794,7 +837,6 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -811,7 +853,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -828,7 +869,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -845,7 +885,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -862,7 +901,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -879,7 +917,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -896,7 +933,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -913,7 +949,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -930,7 +965,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -947,7 +981,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -964,7 +997,6 @@
       "cpu": [
         "ia32"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -981,7 +1013,6 @@
       "cpu": [
         "loong64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -998,7 +1029,6 @@
       "cpu": [
         "mips64el"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1015,7 +1045,6 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1032,7 +1061,6 @@
       "cpu": [
         "riscv64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1049,7 +1077,6 @@
       "cpu": [
         "s390x"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1066,7 +1093,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1083,7 +1109,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1100,7 +1125,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1117,7 +1141,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1134,7 +1157,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1151,7 +1173,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1168,7 +1189,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1185,7 +1205,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1202,7 +1221,6 @@
       "cpu": [
         "ia32"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1219,7 +1237,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3693,7 +3710,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/@img/colour/-/colour-1.0.0.tgz",
       "integrity": "sha512-A5P/LfWGFSl6nsckYtjw9da+19jB8hkJ6ACTGcDfEJ0aE+l2n2El7dsVM7UVHZQ9s2lmYMWlrS21YLy2IR1LUw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -3706,7 +3723,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -3729,7 +3745,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -3752,7 +3767,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -3769,7 +3783,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -3786,7 +3799,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -3803,7 +3815,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -3820,7 +3831,6 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -3837,7 +3847,6 @@
       "cpu": [
         "riscv64"
       ],
-      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -3854,7 +3863,6 @@
       "cpu": [
         "s390x"
       ],
-      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -3871,7 +3879,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -3888,7 +3895,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -3905,7 +3911,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -3922,7 +3927,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -3945,7 +3949,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -3968,7 +3971,6 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -3991,7 +3993,6 @@
       "cpu": [
         "riscv64"
       ],
-      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -4014,7 +4015,6 @@
       "cpu": [
         "s390x"
       ],
-      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -4037,7 +4037,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -4060,7 +4059,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -4083,7 +4081,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -4106,7 +4103,6 @@
       "cpu": [
         "wasm32"
       ],
-      "dev": true,
       "license": "Apache-2.0 AND LGPL-3.0-or-later AND MIT",
       "optional": true,
       "dependencies": {
@@ -4126,7 +4122,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "Apache-2.0 AND LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -4146,7 +4141,6 @@
       "cpu": [
         "ia32"
       ],
-      "dev": true,
       "license": "Apache-2.0 AND LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -4166,7 +4160,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "Apache-2.0 AND LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -4242,7 +4235,7 @@
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
       "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.0.0"
@@ -4252,7 +4245,6 @@
       "version": "1.5.5",
       "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
       "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@jridgewell/trace-mapping": {
@@ -4305,9 +4297,9 @@
       }
     },
     "node_modules/@opentelemetry/api": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.0.tgz",
-      "integrity": "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==",
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.1.tgz",
+      "integrity": "sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==",
       "license": "Apache-2.0",
       "engines": {
         "node": ">=8.0.0"
@@ -4640,7 +4632,7 @@
       "version": "4.1.6",
       "resolved": "https://registry.npmjs.org/@poppinss/colors/-/colors-4.1.6.tgz",
       "integrity": "sha512-H9xkIdFswbS8n1d6vmRd8+c10t2Qe+rZITbbDHHkQixH5+2x1FDGmi/0K+WgWiqQFKPSlIYB7jlH6Kpfn6Fleg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "kleur": "^4.1.5"
@@ -4650,7 +4642,7 @@
       "version": "0.6.5",
       "resolved": "https://registry.npmjs.org/@poppinss/dumper/-/dumper-0.6.5.tgz",
       "integrity": "sha512-NBdYIb90J7LfOI32dOewKI1r7wnkiH6m920puQ3qHUeZkxNkQiFnXVWoE6YtFSv6QOiPPf7ys6i+HWWecDz7sw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@poppinss/colors": "^4.1.5",
@@ -4662,7 +4654,7 @@
       "version": "10.2.2",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-10.2.2.tgz",
       "integrity": "sha512-SS+jx45GF1QjgEXQx4NJZV9ImqmO2NPz5FNsIHrsDjh2YsHnawpan7SNQ1o8NuhrbHZy9AZhIoCUiCeaW/C80g==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -4675,7 +4667,7 @@
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/@poppinss/exception/-/exception-1.2.3.tgz",
       "integrity": "sha512-dCED+QRChTVatE9ibtoaxc+WkdzOSjYTKi/+uacHWIsfodVfpsueo3+DKpgU5Px8qXjgmXkSvhXvSCz3fnP9lw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/@react-aria/breadcrumbs": {
@@ -6525,105 +6517,71 @@
         "win32"
       ]
     },
-    "node_modules/@sentry-internal/browser-utils": {
-      "version": "10.39.0",
-      "resolved": "https://registry.npmjs.org/@sentry-internal/browser-utils/-/browser-utils-10.39.0.tgz",
-      "integrity": "sha512-W6WODonMGiI13Az5P7jd/m2lj/JpIyuVKg7wE4X+YdlMehLspAv6I7gRE4OBSumS14ZjdaYDpD/lwtnBwKAzcA==",
-      "license": "MIT",
-      "dependencies": {
-        "@sentry/core": "10.39.0"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@sentry-internal/feedback": {
-      "version": "10.39.0",
-      "resolved": "https://registry.npmjs.org/@sentry-internal/feedback/-/feedback-10.39.0.tgz",
-      "integrity": "sha512-cRXmmDeOr5FzVsBNRLU4WDEuC3fhuD0XV362EWl4DI3XBGao8ukaueKcLIKic5WZx6uXimjWw/UJmDLgxeCqkg==",
-      "license": "MIT",
-      "dependencies": {
-        "@sentry/core": "10.39.0"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@sentry-internal/replay": {
-      "version": "10.39.0",
-      "resolved": "https://registry.npmjs.org/@sentry-internal/replay/-/replay-10.39.0.tgz",
-      "integrity": "sha512-obZoYOrUfxIYBHkmtPpItRdE38VuzF1VIxSgZ8Mbtq/9UvCWh+eOaVWU2stN/cVu1KYuYX0nQwBvdN28L6y/JA==",
-      "license": "MIT",
-      "dependencies": {
-        "@sentry-internal/browser-utils": "10.39.0",
-        "@sentry/core": "10.39.0"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@sentry-internal/replay-canvas": {
-      "version": "10.39.0",
-      "resolved": "https://registry.npmjs.org/@sentry-internal/replay-canvas/-/replay-canvas-10.39.0.tgz",
-      "integrity": "sha512-TTiX0XWCcqTqFGJjEZYObk93j/sJmXcqPzcu0cN2mIkKnnaHDY3w74SHZCshKqIr0AOQdt1HDNa36s3TCdt0Jw==",
-      "license": "MIT",
-      "dependencies": {
-        "@sentry-internal/replay": "10.39.0",
-        "@sentry/core": "10.39.0"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@sentry/babel-plugin-component-annotate": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/@sentry/babel-plugin-component-annotate/-/babel-plugin-component-annotate-5.0.0.tgz",
-      "integrity": "sha512-z94sxd+TK6z1s7wZhgGq1Bx8k+vJ2iOYQGCn+Vq4R0aon2h8t/n8nacYuHR1C8A/YAF+EfMX7fBuo9Q+JIufbA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 14"
-      }
-    },
     "node_modules/@sentry/browser": {
-      "version": "10.39.0",
-      "resolved": "https://registry.npmjs.org/@sentry/browser/-/browser-10.39.0.tgz",
-      "integrity": "sha512-I50W/1PDJWyqgNrGufGhBYCmmO3Bb159nx2Ut2bKoVveTfgH/hLEtDyW0kHo8Fu454mW+ukyXfU4L4s+kB9aaw==",
+      "version": "10.70.0",
+      "resolved": "https://registry.npmjs.org/@sentry/browser/-/browser-10.70.0.tgz",
+      "integrity": "sha512-IK6+J+8H06tZe+A8L37TT5ZxxwNtyQatW8zl5RYYJ/e9CsjrM8fPi8I1OT7uquTw8UtjqFHt7bEef/Vy63ksPg==",
       "license": "MIT",
       "dependencies": {
-        "@sentry-internal/browser-utils": "10.39.0",
-        "@sentry-internal/feedback": "10.39.0",
-        "@sentry-internal/replay": "10.39.0",
-        "@sentry-internal/replay-canvas": "10.39.0",
-        "@sentry/core": "10.39.0"
+        "@sentry/browser-utils": "10.70.0",
+        "@sentry/conventions": "^0.16.0",
+        "@sentry/core": "10.70.0",
+        "@sentry/feedback": "10.70.0",
+        "@sentry/replay": "10.70.0",
+        "@sentry/replay-canvas": "10.70.0"
       },
       "engines": {
         "node": ">=18"
       }
     },
-    "node_modules/@sentry/bundler-plugin-core": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/@sentry/bundler-plugin-core/-/bundler-plugin-core-5.0.0.tgz",
-      "integrity": "sha512-pjF+RFm6c6vL+sVxSRvSPzZXZQnmzF2BvtqjsMVOhNF+WWFFQPFP3v74HX242fljLeeSStBXpwW/OhW9GXokcg==",
+    "node_modules/@sentry/browser-utils": {
+      "version": "10.70.0",
+      "resolved": "https://registry.npmjs.org/@sentry/browser-utils/-/browser-utils-10.70.0.tgz",
+      "integrity": "sha512-IvjhafF5NFXrPCg5EHbAPGDwIhHxgUcLlHTklZ3DAdA6ky88BJYMfevbcnOEmgavf4nylhCaquRUFNB5+szj+A==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/conventions": "^0.16.0",
+        "@sentry/core": "10.70.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@sentry/bundler-plugins": {
+      "version": "10.70.0",
+      "resolved": "https://registry.npmjs.org/@sentry/bundler-plugins/-/bundler-plugins-10.70.0.tgz",
+      "integrity": "sha512-M+a32VOZVeTUxF+QecQ+OHYj8hb5FeppKwwWpTQ9cfS6ixgoNUK7/B7NhB2XbfxE3F1BcGvOxyS+AB+fvPfSRQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/core": "^7.18.5",
-        "@sentry/babel-plugin-component-annotate": "5.0.0",
-        "@sentry/cli": "^2.57.0",
-        "dotenv": "^16.3.1",
+        "@sentry/cli": "^2.58.6",
+        "@sentry/core": "10.70.0",
+        "dotenv": "^17.4.2",
         "find-up": "^5.0.0",
         "glob": "^13.0.6",
-        "magic-string": "0.30.8"
+        "magic-string": "~0.30.8"
       },
       "engines": {
-        "node": ">= 14"
+        "node": ">= 18"
+      },
+      "peerDependencies": {
+        "rollup": ">=3.2.0",
+        "webpack": ">=5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "rollup": {
+          "optional": true
+        },
+        "webpack": {
+          "optional": true
+        }
       }
     },
-    "node_modules/@sentry/bundler-plugin-core/node_modules/@sentry/cli": {
-      "version": "2.58.5",
-      "resolved": "https://registry.npmjs.org/@sentry/cli/-/cli-2.58.5.tgz",
-      "integrity": "sha512-tavJ7yGUZV+z3Ct2/ZB6mg339i08sAk6HDkgqmSRuQEu2iLS5sl9HIvuXfM6xjv8fwlgFOSy++WNABNAcGHUbg==",
+    "node_modules/@sentry/bundler-plugins/node_modules/@sentry/cli": {
+      "version": "2.58.6",
+      "resolved": "https://registry.npmjs.org/@sentry/cli/-/cli-2.58.6.tgz",
+      "integrity": "sha512-baBcNPLLfUi9WuL+Tpri9BFaAdvugZIKelC5X0tt0Zdy+K0K+PCVSrnNmwMWU/HyaF/SEv6b6UHnXIdqanBlcg==",
       "dev": true,
       "hasInstallScript": true,
       "license": "FSL-1.1-MIT",
@@ -6641,20 +6599,20 @@
         "node": ">= 10"
       },
       "optionalDependencies": {
-        "@sentry/cli-darwin": "2.58.5",
-        "@sentry/cli-linux-arm": "2.58.5",
-        "@sentry/cli-linux-arm64": "2.58.5",
-        "@sentry/cli-linux-i686": "2.58.5",
-        "@sentry/cli-linux-x64": "2.58.5",
-        "@sentry/cli-win32-arm64": "2.58.5",
-        "@sentry/cli-win32-i686": "2.58.5",
-        "@sentry/cli-win32-x64": "2.58.5"
+        "@sentry/cli-darwin": "2.58.6",
+        "@sentry/cli-linux-arm": "2.58.6",
+        "@sentry/cli-linux-arm64": "2.58.6",
+        "@sentry/cli-linux-i686": "2.58.6",
+        "@sentry/cli-linux-x64": "2.58.6",
+        "@sentry/cli-win32-arm64": "2.58.6",
+        "@sentry/cli-win32-i686": "2.58.6",
+        "@sentry/cli-win32-x64": "2.58.6"
       }
     },
-    "node_modules/@sentry/bundler-plugin-core/node_modules/@sentry/cli-darwin": {
-      "version": "2.58.5",
-      "resolved": "https://registry.npmjs.org/@sentry/cli-darwin/-/cli-darwin-2.58.5.tgz",
-      "integrity": "sha512-lYrNzenZFJftfwSya7gwrHGxtE+Kob/e1sr9lmHMFOd4utDlmq0XFDllmdZAMf21fxcPRI1GL28ejZ3bId01fQ==",
+    "node_modules/@sentry/bundler-plugins/node_modules/@sentry/cli-darwin": {
+      "version": "2.58.6",
+      "resolved": "https://registry.npmjs.org/@sentry/cli-darwin/-/cli-darwin-2.58.6.tgz",
+      "integrity": "sha512-udAVvcyfNa0R+95GvPz/+43/N3TC0TYKdkQ7D7jhPSzbcMc7l2fxRNN5yB3UpCA5fWFnW4toeaqwDBhb/Wh3LA==",
       "dev": true,
       "license": "FSL-1.1-MIT",
       "optional": true,
@@ -6665,10 +6623,10 @@
         "node": ">=10"
       }
     },
-    "node_modules/@sentry/bundler-plugin-core/node_modules/@sentry/cli-linux-arm": {
-      "version": "2.58.5",
-      "resolved": "https://registry.npmjs.org/@sentry/cli-linux-arm/-/cli-linux-arm-2.58.5.tgz",
-      "integrity": "sha512-KtHweSIomYL4WVDrBrYSYJricKAAzxUgX86kc6OnlikbyOhoK6Fy8Vs6vwd52P6dvWPjgrMpUYjW2M5pYXQDUw==",
+    "node_modules/@sentry/bundler-plugins/node_modules/@sentry/cli-linux-arm": {
+      "version": "2.58.6",
+      "resolved": "https://registry.npmjs.org/@sentry/cli-linux-arm/-/cli-linux-arm-2.58.6.tgz",
+      "integrity": "sha512-pD0LAt5PcUzAinBwvDqc66x9+2CabHEv486yP0gRjWO7SakbaxmfVq/EXd8VLq/Tzi39LAu422UYK1lpW3MILw==",
       "cpu": [
         "arm"
       ],
@@ -6684,10 +6642,10 @@
         "node": ">=10"
       }
     },
-    "node_modules/@sentry/bundler-plugin-core/node_modules/@sentry/cli-linux-arm64": {
-      "version": "2.58.5",
-      "resolved": "https://registry.npmjs.org/@sentry/cli-linux-arm64/-/cli-linux-arm64-2.58.5.tgz",
-      "integrity": "sha512-/4gywFeBqRB6tR/iGMRAJ3HRqY6Z7Yp4l8ZCbl0TDLAfHNxu7schEw4tSnm2/Hh9eNMiOVy4z58uzAWlZXAYBQ==",
+    "node_modules/@sentry/bundler-plugins/node_modules/@sentry/cli-linux-arm64": {
+      "version": "2.58.6",
+      "resolved": "https://registry.npmjs.org/@sentry/cli-linux-arm64/-/cli-linux-arm64-2.58.6.tgz",
+      "integrity": "sha512-q8mEcNNmeXMy5i+jWT30TVpH7LcP4HD21CD5XRSPAd/a912HF6EpK0ybf/1USO14WOhoXbAGi9txwaWabSe33g==",
       "cpu": [
         "arm64"
       ],
@@ -6703,10 +6661,10 @@
         "node": ">=10"
       }
     },
-    "node_modules/@sentry/bundler-plugin-core/node_modules/@sentry/cli-linux-i686": {
-      "version": "2.58.5",
-      "resolved": "https://registry.npmjs.org/@sentry/cli-linux-i686/-/cli-linux-i686-2.58.5.tgz",
-      "integrity": "sha512-G7261dkmyxqlMdyvyP06b+RTIVzp1gZNgglj5UksxSouSUqRd/46W/2pQeOMPhloDYo9yLtCN2YFb3Mw4aUsWw==",
+    "node_modules/@sentry/bundler-plugins/node_modules/@sentry/cli-linux-i686": {
+      "version": "2.58.6",
+      "resolved": "https://registry.npmjs.org/@sentry/cli-linux-i686/-/cli-linux-i686-2.58.6.tgz",
+      "integrity": "sha512-q8vNJi1eOV/4vxAFWBsEwLHoSYapaZHIf4j76KJGJXFKTkEbsjCOOsKbwUIBTQQhRgV4DFWh3ryfsPS/que4Kg==",
       "cpu": [
         "x86",
         "ia32"
@@ -6723,10 +6681,10 @@
         "node": ">=10"
       }
     },
-    "node_modules/@sentry/bundler-plugin-core/node_modules/@sentry/cli-linux-x64": {
-      "version": "2.58.5",
-      "resolved": "https://registry.npmjs.org/@sentry/cli-linux-x64/-/cli-linux-x64-2.58.5.tgz",
-      "integrity": "sha512-rP04494RSmt86xChkQ+ecBNRYSPbyXc4u0IA7R7N1pSLCyO74e5w5Al+LnAq35cMfVbZgz5Sm0iGLjyiUu4I1g==",
+    "node_modules/@sentry/bundler-plugins/node_modules/@sentry/cli-linux-x64": {
+      "version": "2.58.6",
+      "resolved": "https://registry.npmjs.org/@sentry/cli-linux-x64/-/cli-linux-x64-2.58.6.tgz",
+      "integrity": "sha512-DZu956Mhi3ZRjTBe1WdbGV46ldVbA8d2rgp/fh51GsI25zjBHah4wZnPTSzpc+YqxU6pJpg579B/r3jrIK530Q==",
       "cpu": [
         "x64"
       ],
@@ -6742,10 +6700,10 @@
         "node": ">=10"
       }
     },
-    "node_modules/@sentry/bundler-plugin-core/node_modules/@sentry/cli-win32-arm64": {
-      "version": "2.58.5",
-      "resolved": "https://registry.npmjs.org/@sentry/cli-win32-arm64/-/cli-win32-arm64-2.58.5.tgz",
-      "integrity": "sha512-AOJ2nCXlQL1KBaCzv38m3i2VmSHNurUpm7xVKd6yAHX+ZoVBI8VT0EgvwmtJR2TY2N2hNCC7UrgRmdUsQ152bA==",
+    "node_modules/@sentry/bundler-plugins/node_modules/@sentry/cli-win32-arm64": {
+      "version": "2.58.6",
+      "resolved": "https://registry.npmjs.org/@sentry/cli-win32-arm64/-/cli-win32-arm64-2.58.6.tgz",
+      "integrity": "sha512-nj0Ff/kmAB73EPDhR8B4O9r+NUHK5GkPCkGWC+kXVemqAJWL5jcJ5KdxG0l/S0z6RoEoltID8/43/B+TaMlT7A==",
       "cpu": [
         "arm64"
       ],
@@ -6759,10 +6717,10 @@
         "node": ">=10"
       }
     },
-    "node_modules/@sentry/bundler-plugin-core/node_modules/@sentry/cli-win32-i686": {
-      "version": "2.58.5",
-      "resolved": "https://registry.npmjs.org/@sentry/cli-win32-i686/-/cli-win32-i686-2.58.5.tgz",
-      "integrity": "sha512-EsuboLSOnlrN7MMPJ1eFvfMDm+BnzOaSWl8eYhNo8W/BIrmNgpRUdBwnWn9Q2UOjJj5ZopukmsiMYtU/D7ml9g==",
+    "node_modules/@sentry/bundler-plugins/node_modules/@sentry/cli-win32-i686": {
+      "version": "2.58.6",
+      "resolved": "https://registry.npmjs.org/@sentry/cli-win32-i686/-/cli-win32-i686-2.58.6.tgz",
+      "integrity": "sha512-WNZiDzPbgsEMQWq4avsQ391v/xWKJDIWWWo9GYl+N/w5qcYKkoDW7wQG7T9FasI6ENn68phChTOAPXXxbfAdOg==",
       "cpu": [
         "x86",
         "ia32"
@@ -6777,10 +6735,10 @@
         "node": ">=10"
       }
     },
-    "node_modules/@sentry/bundler-plugin-core/node_modules/@sentry/cli-win32-x64": {
-      "version": "2.58.5",
-      "resolved": "https://registry.npmjs.org/@sentry/cli-win32-x64/-/cli-win32-x64-2.58.5.tgz",
-      "integrity": "sha512-IZf+XIMiQwj+5NzqbOQfywlOitmCV424Vtf9c+ep61AaVScUFD1TSrQbOcJJv5xGxhlxNOMNgMeZhdexdzrKZg==",
+    "node_modules/@sentry/bundler-plugins/node_modules/@sentry/cli-win32-x64": {
+      "version": "2.58.6",
+      "resolved": "https://registry.npmjs.org/@sentry/cli-win32-x64/-/cli-win32-x64-2.58.6.tgz",
+      "integrity": "sha512-R35WJ17oF4D2eqI1DR2sQQqr0fjRTt5xoP16WrTu91XM2lndRMFsnjh+/GttbxapLCBNlrjzia99MJ0PZHZpgA==",
       "cpu": [
         "x64"
       ],
@@ -6794,7 +6752,7 @@
         "node": ">=10"
       }
     },
-    "node_modules/@sentry/bundler-plugin-core/node_modules/agent-base": {
+    "node_modules/@sentry/bundler-plugins/node_modules/agent-base": {
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
       "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
@@ -6807,7 +6765,7 @@
         "node": ">= 6.0.0"
       }
     },
-    "node_modules/@sentry/bundler-plugin-core/node_modules/https-proxy-agent": {
+    "node_modules/@sentry/bundler-plugins/node_modules/https-proxy-agent": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
       "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
@@ -6821,23 +6779,10 @@
         "node": ">= 6"
       }
     },
-    "node_modules/@sentry/bundler-plugin-core/node_modules/magic-string": {
-      "version": "0.30.8",
-      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.8.tgz",
-      "integrity": "sha512-ISQTe55T2ao7XtlAStud6qwYPZjE4GK1S/BeVPus4jrq6JuOnQ00YKQC581RWhR122W7msZV263KzVeLoqidyQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@jridgewell/sourcemap-codec": "^1.4.15"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
     "node_modules/@sentry/cli": {
-      "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/@sentry/cli/-/cli-3.2.2.tgz",
-      "integrity": "sha512-qmjsm9+Bq/3QGTnIfOsJdhq+8LI3imxAPbGNBpRj4R0YFk+b1ry9huRHCLgkMcRFWtPkJmGZwEq2Z7e+02QPLA==",
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/@sentry/cli/-/cli-3.6.2.tgz",
+      "integrity": "sha512-/OcDsuz005C1tuauNhTd8/XNBHCfHiy46Wru4hAKBaziywgSA52lMSEznh6mWmHjPe/FoaDLpYt3Zd9qk3G0RA==",
       "hasInstallScript": true,
       "license": "FSL-1.1-MIT",
       "dependencies": {
@@ -6853,20 +6798,20 @@
         "node": ">= 18"
       },
       "optionalDependencies": {
-        "@sentry/cli-darwin": "3.2.2",
-        "@sentry/cli-linux-arm": "3.2.2",
-        "@sentry/cli-linux-arm64": "3.2.2",
-        "@sentry/cli-linux-i686": "3.2.2",
-        "@sentry/cli-linux-x64": "3.2.2",
-        "@sentry/cli-win32-arm64": "3.2.2",
-        "@sentry/cli-win32-i686": "3.2.2",
-        "@sentry/cli-win32-x64": "3.2.2"
+        "@sentry/cli-darwin": "3.6.2",
+        "@sentry/cli-linux-arm": "3.6.2",
+        "@sentry/cli-linux-arm64": "3.6.2",
+        "@sentry/cli-linux-i686": "3.6.2",
+        "@sentry/cli-linux-x64": "3.6.2",
+        "@sentry/cli-win32-arm64": "3.6.2",
+        "@sentry/cli-win32-i686": "3.6.2",
+        "@sentry/cli-win32-x64": "3.6.2"
       }
     },
     "node_modules/@sentry/cli-darwin": {
-      "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/@sentry/cli-darwin/-/cli-darwin-3.2.2.tgz",
-      "integrity": "sha512-y1uglMBbo9dYqC92hTQBkuGk7SegLPo1cVwJzX0dhplJoBMuanLMhOMYd1J20qhkDdBhguflCHGf0tOzNTGWhg==",
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/@sentry/cli-darwin/-/cli-darwin-3.6.2.tgz",
+      "integrity": "sha512-/ZIMLblj6ncwguhOPw5YL9018iaD2RBhxhbHBxjaowy1vrmnzoCurGe4n5Vv7PaS21ldAHtHNqJwNqHJS4XHUw==",
       "license": "FSL-1.1-MIT",
       "optional": true,
       "os": [
@@ -6877,9 +6822,9 @@
       }
     },
     "node_modules/@sentry/cli-linux-arm": {
-      "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/@sentry/cli-linux-arm/-/cli-linux-arm-3.2.2.tgz",
-      "integrity": "sha512-CC7N3hjOgs3cwrW0T9hqirFVUpKO6ASjdd0JT4DQHaAn34pruv8J+OoSnj1jkrT2DHxDkNNZPOFSK05AnHr8wA==",
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/@sentry/cli-linux-arm/-/cli-linux-arm-3.6.2.tgz",
+      "integrity": "sha512-b2M+1ujgf7jHig9r88T2l2HEkg0XR/1Tmo1LCiPg4dsPKtTMC2Rb/f0Mto83//zkVijAA2WDBhznOz9a9Ouo7Q==",
       "cpu": [
         "arm"
       ],
@@ -6895,9 +6840,9 @@
       }
     },
     "node_modules/@sentry/cli-linux-arm64": {
-      "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/@sentry/cli-linux-arm64/-/cli-linux-arm64-3.2.2.tgz",
-      "integrity": "sha512-SIGJknEQNDw9S/8QPTl8QLVe2IEiTKH3NeeHQ/Q2XWXig1ZebJfm4iTrdu47ypszIfxHeLvQkkVrr8mRKq16xA==",
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/@sentry/cli-linux-arm64/-/cli-linux-arm64-3.6.2.tgz",
+      "integrity": "sha512-KMHW+CIT5H046I1hIYJ6vZmwlbBELZDOTt9Bgue3kqpW5CuvviMeMuuIKXM2oKHr/l4Q1Xnj07oTbVNb1opTsg==",
       "cpu": [
         "arm64"
       ],
@@ -6913,9 +6858,9 @@
       }
     },
     "node_modules/@sentry/cli-linux-i686": {
-      "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/@sentry/cli-linux-i686/-/cli-linux-i686-3.2.2.tgz",
-      "integrity": "sha512-W2hQ2DvIlZI05j2JN/87lfeo51F24zmQOJU6Uz+fZz/mkSvpnjeWxjAvfDNVGlLxp7XSoDbhHfrLBxdIh6jMeg==",
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/@sentry/cli-linux-i686/-/cli-linux-i686-3.6.2.tgz",
+      "integrity": "sha512-tsLTOfJBoUkHfcCjUKxb/w1/WGLU00WJUO5zJztgLHKlebrjGAEiKM+8EPexb2hiW4F/P6UXL+4xXPKANk5JXQ==",
       "cpu": [
         "x86",
         "ia32"
@@ -6932,9 +6877,9 @@
       }
     },
     "node_modules/@sentry/cli-linux-x64": {
-      "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/@sentry/cli-linux-x64/-/cli-linux-x64-3.2.2.tgz",
-      "integrity": "sha512-4mh3yvOUxO63lq3teexRvalD1mWaRVjpgL2cCMKA2wkB69lcL5nK2gkdzDUKx2y/elluVdvGPPZaqOr1bfNI0w==",
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/@sentry/cli-linux-x64/-/cli-linux-x64-3.6.2.tgz",
+      "integrity": "sha512-CHwfSJYkPe4w96EovIY/iWfxHnf5gvRYh0BGHCPcQ9knhrgWUJqbHqi3lNfEDZmzCxJ76RqPrnLMW6syoSqXow==",
       "cpu": [
         "x64"
       ],
@@ -6950,9 +6895,9 @@
       }
     },
     "node_modules/@sentry/cli-win32-arm64": {
-      "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/@sentry/cli-win32-arm64/-/cli-win32-arm64-3.2.2.tgz",
-      "integrity": "sha512-TQgfkdJgd8Y/lPzDibqc5Hamg8Hl5rN1sZwX80n4r9Ly46Yzu8Bv6KUhoNL/ktAvw9Aeko6Bx54rwZnzxFZHwg==",
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/@sentry/cli-win32-arm64/-/cli-win32-arm64-3.6.2.tgz",
+      "integrity": "sha512-lTqOPbLexkKnXmuIK8qszv+trpX8fQiZAJoeClVA1+hOerVyrLP9eU2tUqTm/8YW8G/M+mu3ZxAtDvS3OpHvZw==",
       "cpu": [
         "arm64"
       ],
@@ -6966,9 +6911,9 @@
       }
     },
     "node_modules/@sentry/cli-win32-i686": {
-      "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/@sentry/cli-win32-i686/-/cli-win32-i686-3.2.2.tgz",
-      "integrity": "sha512-vAcnq0SdYuvwIdREgF5APocjW3d9Z17xLwugpaAz8wpOjCeC1iMEFWqbz5k49i4iDkDVNFRMENiVvWVSu1kEnA==",
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/@sentry/cli-win32-i686/-/cli-win32-i686-3.6.2.tgz",
+      "integrity": "sha512-niUPoxN8p7jWrkvC0ekgpcIYEJNb5YxmuXRjUnOJrArwQs+4OPzRM+3e6JIYRXe7RDoUP63j1voYakEncuxioQ==",
       "cpu": [
         "x86",
         "ia32"
@@ -6983,9 +6928,9 @@
       }
     },
     "node_modules/@sentry/cli-win32-x64": {
-      "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/@sentry/cli-win32-x64/-/cli-win32-x64-3.2.2.tgz",
-      "integrity": "sha512-xWPTXjSSdmoyG/0ee7A9KSfsScGHCdaXMP6ASt4bMx3yYJO7ziEoZzfJE2M6oglz+woAm0LV9+O/n7g80tixlQ==",
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/@sentry/cli-win32-x64/-/cli-win32-x64-3.6.2.tgz",
+      "integrity": "sha512-Xg6ieuJr/1Ewtdpm9Kudb029lJxnfs3Ae/fLZNAOnvWOie/V4V/X+tgZ+lETC3lU+7yz7Gb0f25gKnU6sPBKVg==",
       "cpu": [
         "x64"
       ],
@@ -7008,43 +6953,74 @@
       }
     },
     "node_modules/@sentry/cloudflare": {
-      "version": "10.39.0",
-      "resolved": "https://registry.npmjs.org/@sentry/cloudflare/-/cloudflare-10.39.0.tgz",
-      "integrity": "sha512-x0DDNJJ1sDuHosFKURcn6I7eMQfJKNF317NclARgE6a+sg0Ty5OpaNMaQF9VlPVDB7JGXohADJ+88I1x0mB87g==",
+      "version": "10.70.0",
+      "resolved": "https://registry.npmjs.org/@sentry/cloudflare/-/cloudflare-10.70.0.tgz",
+      "integrity": "sha512-jlr9txw3lQrbc6KQn9FzlpgC1KcB36u7aIGSlUhXAZ2MB93DgwjuTnHF20qQHxmHbZylg7CtHoMq3rGiTXAgpg==",
       "license": "MIT",
       "dependencies": {
-        "@opentelemetry/api": "^1.9.0",
-        "@sentry/core": "10.39.0"
+        "@opentelemetry/api": "^1.9.1",
+        "@sentry/core": "10.70.0",
+        "@sentry/server-utils": "10.70.0",
+        "magic-string": "~0.30.21"
       },
       "engines": {
         "node": ">=18"
       },
       "peerDependencies": {
-        "@cloudflare/workers-types": "^4.x"
+        "@cloudflare/workers-types": "^4.x || ^5.x",
+        "wrangler": "^4.x"
       },
       "peerDependenciesMeta": {
         "@cloudflare/workers-types": {
           "optional": true
+        },
+        "wrangler": {
+          "optional": true
         }
       }
     },
-    "node_modules/@sentry/core": {
-      "version": "10.39.0",
-      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-10.39.0.tgz",
-      "integrity": "sha512-xCLip2mBwCdRrvXHtVEULX0NffUTYZZBhEUGht0WFL+GNdNQ7gmBOGOczhZlrf2hgFFtDO0fs1xiP9bqq5orEQ==",
+    "node_modules/@sentry/conventions": {
+      "version": "0.16.0",
+      "resolved": "https://registry.npmjs.org/@sentry/conventions/-/conventions-0.16.0.tgz",
+      "integrity": "sha512-fO9PLmHdVURcSPUpWCItWAtgKiMwGdJHbovoSEyLplX5sxs2ugvI4CBPTrkkgqhObnZOD0CnWBKDzSVQYBKEyQ==",
       "license": "MIT",
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@sentry/core": {
+      "version": "10.70.0",
+      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-10.70.0.tgz",
+      "integrity": "sha512-ozhCTDqg89oB4XmWfAwuHshABpvT7AkRpaPnogopPfMAaI61G1t8EKCJ4W7aum8JSBonlfyjPCyW5oYZFm0KvA==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/conventions": "^0.16.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@sentry/feedback": {
+      "version": "10.70.0",
+      "resolved": "https://registry.npmjs.org/@sentry/feedback/-/feedback-10.70.0.tgz",
+      "integrity": "sha512-6VQn2ETJjHkk4QQDdx/587/JDfXsk3yBTLZ3UZOMtBVrkmwgk+1FJZ8ULJ3ud1xZcuh2icunIkc7tGVv2axdnw==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/core": "10.70.0"
+      },
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@sentry/react": {
-      "version": "10.39.0",
-      "resolved": "https://registry.npmjs.org/@sentry/react/-/react-10.39.0.tgz",
-      "integrity": "sha512-qxReWHFhDcXNGEyAlYzhR7+K70es+vXaSknTZui1q7TfQwCT1rZlLKn/K8GDpNsb35RC5QhiIphU6pKbyYgZqw==",
+      "version": "10.70.0",
+      "resolved": "https://registry.npmjs.org/@sentry/react/-/react-10.70.0.tgz",
+      "integrity": "sha512-j1d/4hvoaUVKs5GRrfmwUCkiEmkfaeHsk+xgausZlzg5YvmwpF+gyevBLNP26GFEH7nyHXW4l8dbbo0eNieJmw==",
       "license": "MIT",
       "dependencies": {
-        "@sentry/browser": "10.39.0",
-        "@sentry/core": "10.39.0"
+        "@sentry/browser": "10.70.0",
+        "@sentry/conventions": "^0.16.0",
+        "@sentry/core": "10.70.0"
       },
       "engines": {
         "node": ">=18"
@@ -7053,55 +7029,66 @@
         "react": "^16.14.0 || 17.x || 18.x || 19.x"
       }
     },
-    "node_modules/@sentry/rollup-plugin": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/@sentry/rollup-plugin/-/rollup-plugin-5.0.0.tgz",
-      "integrity": "sha512-XSsqthe1oUoJE7cBGbsfd0qfV5VuVe7T8NMyofatgHFZw7GqamczTb5jBRMBb3ZT+ZqffDOiSsS6n3l0b82jRg==",
-      "dev": true,
+    "node_modules/@sentry/replay": {
+      "version": "10.70.0",
+      "resolved": "https://registry.npmjs.org/@sentry/replay/-/replay-10.70.0.tgz",
+      "integrity": "sha512-xMnSGzJn9Xd29rYd32lkx/gFW+5mtgqADJ2FiZvis0MBGZuDlNRwPn0/Cs1xA3JNXKV3NGfhdmmvs90w4dHSmw==",
       "license": "MIT",
       "dependencies": {
-        "@sentry/bundler-plugin-core": "5.0.0",
-        "magic-string": "0.30.8"
+        "@sentry/browser-utils": "10.70.0",
+        "@sentry/core": "10.70.0"
       },
       "engines": {
-        "node": ">= 14"
-      },
-      "peerDependencies": {
-        "rollup": ">=3.2.0"
+        "node": ">=18"
       }
     },
-    "node_modules/@sentry/rollup-plugin/node_modules/magic-string": {
-      "version": "0.30.8",
-      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.8.tgz",
-      "integrity": "sha512-ISQTe55T2ao7XtlAStud6qwYPZjE4GK1S/BeVPus4jrq6JuOnQ00YKQC581RWhR122W7msZV263KzVeLoqidyQ==",
-      "dev": true,
+    "node_modules/@sentry/replay-canvas": {
+      "version": "10.70.0",
+      "resolved": "https://registry.npmjs.org/@sentry/replay-canvas/-/replay-canvas-10.70.0.tgz",
+      "integrity": "sha512-irzpw22bK5CF3jbecDa0gBUcfjv7tgeUoLAvtIfeHOP5ajmf3o4Cp99a9RQqkfgvkcMeRZBUwE91SQhp6Ank+w==",
       "license": "MIT",
       "dependencies": {
-        "@jridgewell/sourcemap-codec": "^1.4.15"
+        "@sentry/core": "10.70.0",
+        "@sentry/replay": "10.70.0"
       },
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
+      }
+    },
+    "node_modules/@sentry/server-utils": {
+      "version": "10.70.0",
+      "resolved": "https://registry.npmjs.org/@sentry/server-utils/-/server-utils-10.70.0.tgz",
+      "integrity": "sha512-rzegZjMFFgCp3o+N8+XU13rfSvz4B+f8rU0ijBGrQcHdMNyfsFDTu1UTm262JofmrV2u+s+D0u0vFTnqtOGkbA==",
+      "license": "MIT",
+      "dependencies": {
+        "@apm-js-collab/code-transformer-bundler-plugins": "^0.7.3",
+        "@apm-js-collab/tracing-hooks": "^0.13.0",
+        "@sentry/conventions": "^0.16.0",
+        "@sentry/core": "10.70.0",
+        "meriyah": "^6.1.4"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@sentry/vite-plugin": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/@sentry/vite-plugin/-/vite-plugin-5.0.0.tgz",
-      "integrity": "sha512-Np7J4DoeQuQEEQ7lU2Ta2PwLYixXXBFvVQFftvBp/9umRdrMkMc6lUQ+XpQhJmJTUe7cR5+u0tjGXguFikJd8g==",
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/@sentry/vite-plugin/-/vite-plugin-5.4.0.tgz",
+      "integrity": "sha512-fFJgCxs5hDyAm9BbZJ+LbA+LK2tjX5OoD0v0ARU4StR6KQmGUduoPs69yJ9AfqZ0om3Rlp5JDliiwFcNkasORA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@sentry/bundler-plugin-core": "5.0.0",
-        "@sentry/rollup-plugin": "5.0.0"
+        "@sentry/bundler-plugins": "^10.64.0"
       },
       "engines": {
-        "node": ">= 14"
+        "node": ">= 18"
       }
     },
     "node_modules/@sindresorhus/is": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-7.2.0.tgz",
       "integrity": "sha512-P1Cz1dWaFfR4IR+U13mqqiGsLFf1KbayybWwdd2vfctdV6hDpUkgCY0nKOLLTMSoRd/jJNjtbqzf13K8DCCXQw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -7114,7 +7101,7 @@
       "version": "1.2.14",
       "resolved": "https://registry.npmjs.org/@speed-highlight/core/-/core-1.2.14.tgz",
       "integrity": "sha512-G4ewlBNhUtlLvrJTb88d2mdy2KRijzs4UhnlrOSRT4bmjh/IqNElZa3zkrZ+TC47TwtlDWzVLFADljF1Ijp5hA==",
-      "dev": true,
+      "devOptional": true,
       "license": "CC0-1.0"
     },
     "node_modules/@standard-schema/spec": {
@@ -8061,6 +8048,15 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/astring": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/astring/-/astring-1.9.0.tgz",
+      "integrity": "sha512-LElXdjswlqjWrPpJFg1Fx4wpkOCxj1TDHlSV4PlaRxHGWko024xICaa97ZkMfs6DRKlCguiAI+rbXv5GWwXIkg==",
+      "license": "MIT",
+      "bin": {
+        "astring": "bin/astring"
+      }
+    },
     "node_modules/babel-plugin-react-compiler": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-react-compiler/-/babel-plugin-react-compiler-1.0.0.tgz",
@@ -8121,20 +8117,20 @@
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/blake3-wasm/-/blake3-wasm-2.1.5.tgz",
       "integrity": "sha512-F1+K8EbfOZE49dtoPtmxUQrpXaBIl3ICvasLh+nJta0xkz+9kF/7uet9fLnwKqhDrmj6g+6K3Tw9yQPUg2ka5g==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.3",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.3.tgz",
-      "integrity": "sha512-fy6KJm2RawA5RcHkLa1z/ScpBeA762UF9KmZQxwIbDtRJrgLzM10depAiEQ+CXYcoiqW1/m96OAAoke2nE9EeA==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
       },
       "engines": {
-        "node": "18 || 20 || >=22"
+        "node": "20 || >=22"
       }
     },
     "node_modules/brace-expansion/node_modules/balanced-match": {
@@ -8785,7 +8781,7 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
       "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0",
       "engines": {
         "node": ">=8"
@@ -8839,9 +8835,9 @@
       "peer": true
     },
     "node_modules/dotenv": {
-      "version": "16.6.1",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.6.1.tgz",
-      "integrity": "sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==",
+      "version": "17.4.2",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.4.2.tgz",
+      "integrity": "sha512-nI4U3TottKAcAD9LLud4Cb7b2QztQMUEfHbvhTH09bqXTxnSie8WnjPALV/WMCrJZ6UV/qHJ6L03OqO3LcdYZw==",
       "dev": true,
       "license": "BSD-2-Clause",
       "engines": {
@@ -8909,7 +8905,7 @@
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/error-stack-parser-es/-/error-stack-parser-es-1.0.5.tgz",
       "integrity": "sha512-5qucVt2XcuGMcEGgWI7i+yZpmpByQ8J1lHhcL7PwqCwu9FPP3VUXzT4ltHe5i2z9dePwEHcDVOAfSnHsOlCXRA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/antfu"
@@ -8936,7 +8932,7 @@
       "version": "0.27.3",
       "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.3.tgz",
       "integrity": "sha512-8VwMnyGCONIs6cWue2IdpHxHnAjzxnw2Zr7MkVxB2vjmQ2ivqGFb4LEG3SMnv0Gb2F/G/2yA8zUaiL1gywDCCg==",
-      "dev": true,
+      "devOptional": true,
       "hasInstallScript": true,
       "license": "MIT",
       "bin": {
@@ -8982,6 +8978,27 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/esquery": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.7.0.tgz",
+      "integrity": "sha512-Ap6G0WQwcU/LHsvLwON1fAQX9Zp0A2Y6Y/cJBl9r/JbW90Zyg4/zbG6zzKa2OTALELarYHmKu0GhpM5EO+7T0g==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "estraverse": "^5.1.0"
+      },
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
+    "node_modules/estraverse": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
+      "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=4.0"
       }
     },
     "node_modules/estree-util-is-identifier-name": {
@@ -9128,7 +9145,6 @@
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
       "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
-      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -9214,13 +9230,13 @@
       }
     },
     "node_modules/glob/node_modules/minimatch": {
-      "version": "10.2.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.2.tgz",
-      "integrity": "sha512-+G4CpNBxa5MprY+04MbgOw1v7So6n5JY166pFi9KfYwT78fxScCeSNQSNzp6dpPSW2rONOps6Ocam1wFhCgoVw==",
+      "version": "10.2.6",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.6.tgz",
+      "integrity": "sha512-vpLQEs+VLCr1nU0BXS07maYoFwlDAH0gngQuuttxIwutDFEMHq2blX+8vpgxDdK3J1PwjCJiep77OitTZ4Ll1A==",
       "dev": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
-        "brace-expansion": "^5.0.2"
+        "brace-expansion": "^5.0.8"
       },
       "engines": {
         "node": "18 || 20 || >=22"
@@ -9709,7 +9725,7 @@
       "version": "4.1.5",
       "resolved": "https://registry.npmjs.org/kleur/-/kleur-4.1.5.tgz",
       "integrity": "sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -10097,7 +10113,6 @@
       "version": "0.30.21",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
       "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.5"
@@ -10299,6 +10314,15 @@
       "license": "MIT",
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/meriyah": {
+      "version": "6.1.4",
+      "resolved": "https://registry.npmjs.org/meriyah/-/meriyah-6.1.4.tgz",
+      "integrity": "sha512-Sz8FzjzI0kN13GK/6MVEsVzMZEPvOhnmmI1lU5+/1cGOiK3QUahntrNNtdVeihrO7t9JpoH75iMNXg6R6uWflQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=18.0.0"
       }
     },
     "node_modules/micromark": {
@@ -10784,7 +10808,7 @@
       "version": "4.20260302.0",
       "resolved": "https://registry.npmjs.org/miniflare/-/miniflare-4.20260302.0.tgz",
       "integrity": "sha512-joGFywlo7HdfHXXGOkc6tDCVkwjEncM0mwEsMOLWcl+vDVJPj9HRV7JtEa0+lCpNOLdYw7mZNHYe12xz9KtJOw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@cspotcode/source-map-support": "0.8.1",
@@ -10805,7 +10829,7 @@
       "version": "8.18.0",
       "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.0.tgz",
       "integrity": "sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"
@@ -10848,6 +10872,12 @@
       "engines": {
         "node": ">=16 || 14 >=14.17"
       }
+    },
+    "node_modules/module-details-from-path": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/module-details-from-path/-/module-details-from-path-1.0.4.tgz",
+      "integrity": "sha512-EGWKgxALGMgzvxYF1UyGTy0HXX/2vHLkw6+NvDKW2jypWbHpjQuj4UMcqQWXHERJhVGKikolT06G3bcKe4fi7w==",
+      "license": "MIT"
     },
     "node_modules/motion-dom": {
       "version": "12.34.3",
@@ -11175,9 +11205,9 @@
       }
     },
     "node_modules/path-scurry/node_modules/lru-cache": {
-      "version": "11.2.6",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.6.tgz",
-      "integrity": "sha512-ESL2CrkS/2wTPfuend7Zhkzo2u0daGJ/A2VucJOgQ/C48S/zB8MMeMHSGKYpXhIjbPxfuezITkaBH1wqv00DDQ==",
+      "version": "11.5.2",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.2.tgz",
+      "integrity": "sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==",
       "dev": true,
       "license": "BlueOak-1.0.0",
       "engines": {
@@ -11188,7 +11218,7 @@
       "version": "6.3.0",
       "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.3.0.tgz",
       "integrity": "sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/path-type": {
@@ -11205,7 +11235,7 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
       "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/picocolors": {
@@ -11924,11 +11954,17 @@
       "integrity": "sha512-8OwmbklUNzwezjGInmZ+2clQmExQPvomqjL7LFqOYqtmuxRgQYqOD3mHaU+MvZn5FLUeVxVfQjwLZW/n/JFuqg==",
       "license": "MIT"
     },
+    "node_modules/semifies": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/semifies/-/semifies-1.0.0.tgz",
+      "integrity": "sha512-xXR3KGeoxTNWPD4aBvL5NUpMTT7WMANr3EWnaS190QVkY52lqqcVRD7Q05UVbBhiWDGWMlJEUam9m7uFFGVScw==",
+      "license": "Apache-2.0"
+    },
     "node_modules/semver": {
       "version": "7.7.3",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.3.tgz",
       "integrity": "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==",
-      "dev": true,
+      "devOptional": true,
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
@@ -11947,7 +11983,7 @@
       "version": "0.34.5",
       "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.34.5.tgz",
       "integrity": "sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg==",
-      "dev": true,
+      "devOptional": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -12252,6 +12288,15 @@
       },
       "engines": {
         "node": ">=20"
+      }
+    },
+    "node_modules/source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/source-map-js": {
@@ -12745,7 +12790,7 @@
       "version": "7.18.2",
       "resolved": "https://registry.npmjs.org/undici/-/undici-7.18.2.tgz",
       "integrity": "sha512-y+8YjDFzWdQlSE9N5nzKMT3g4a5UBX1HKowfdXh0uvAnTaqqwqB92Jt4UXBAeKekDs5IaDKyJFR4X1gYVCgXcw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=20.18.1"
@@ -12755,7 +12800,7 @@
       "version": "2.0.0-rc.24",
       "resolved": "https://registry.npmjs.org/unenv/-/unenv-2.0.0-rc.24.tgz",
       "integrity": "sha512-i7qRCmY42zmCwnYlh9H2SvLEypEFGye5iRmEMKjcGi7zk9UquigRjFtTLz0TYqr0ZGLZhaMHl/foy1bZR+Cwlw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "pathe": "^2.0.3"
@@ -13246,7 +13291,7 @@
       "version": "1.20260302.0",
       "resolved": "https://registry.npmjs.org/workerd/-/workerd-1.20260302.0.tgz",
       "integrity": "sha512-FhNdC8cenMDllI6bTktFgxP5Bn5ZEnGtofgKipY6pW9jtq708D1DeGI6vGad78KQLBGaDwFy1eThjCoLYgFfog==",
-      "dev": true,
+      "devOptional": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "bin": {
@@ -13267,7 +13312,7 @@
       "version": "4.68.0",
       "resolved": "https://registry.npmjs.org/wrangler/-/wrangler-4.68.0.tgz",
       "integrity": "sha512-DCjl2ZfjwWV10iH4Zn+97isitPkb7BYxpbt4E/Okd/QKLFTp9xdwoa999UN9lugToqPm5Zz/UsRu6hpKZuT8BA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT OR Apache-2.0",
       "dependencies": {
         "@cloudflare/kv-asset-handler": "0.4.2",
@@ -13495,7 +13540,7 @@
       "version": "4.1.0-beta.10",
       "resolved": "https://registry.npmjs.org/youch/-/youch-4.1.0-beta.10.tgz",
       "integrity": "sha512-rLfVLB4FgQneDr0dv1oddCVZmKjcJ6yX6mS4pU82Mq/Dt9a3cLZQ62pDBL4AUO+uVrCvtWz3ZFUL2HFAFJ/BXQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@poppinss/colors": "^4.1.5",
@@ -13509,7 +13554,7 @@
       "version": "0.3.3",
       "resolved": "https://registry.npmjs.org/youch-core/-/youch-core-0.3.3.tgz",
       "integrity": "sha512-ho7XuGjLaJ2hWHoK8yFnsUGy2Y5uDpqSTq1FkHLK4/oqKtyUU1AFbOOxY4IpC9f0fTLjwYbslUz0Po5BpD1wrA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@poppinss/exception": "^1.2.2",
@@ -13542,8 +13587,8 @@
         "@ctrl/tinycolor": "4.2.0",
         "@hono/zod-validator": "0.7.6",
         "@repo/shared": "*",
-        "@sentry/cli": "3.2.2",
-        "@sentry/cloudflare": "10.39.0",
+        "@sentry/cli": "3.6.2",
+        "@sentry/cloudflare": "10.70.0",
         "hono": "4.12.2",
         "zod": "4.3.6"
       },
@@ -13584,7 +13629,7 @@
       "version": "0.0.0",
       "dependencies": {
         "@ctrl/tinycolor": "4.2.0",
-        "@sentry/cli": "3.2.2",
+        "@sentry/cli": "3.6.2",
         "nanoid": "5.1.6",
         "react": "19.2.4",
         "zod": "4.3.6"

--- a/package-lock.json
+++ b/package-lock.json
@@ -7012,6 +7012,49 @@
         "node": ">=18"
       }
     },
+    "node_modules/@sentry/hono": {
+      "version": "10.70.0",
+      "resolved": "https://registry.npmjs.org/@sentry/hono/-/hono-10.70.0.tgz",
+      "integrity": "sha512-d3Zcsd8k6KxdXC9xkbD5a2T8JTsv1VBaYfgov3SYcQ6zeCNBVCnSSp/Q+/KMdCBv/clXbuUbDsyfWG494txz8g==",
+      "license": "MIT",
+      "dependencies": {
+        "@opentelemetry/api": "^1.9.1",
+        "@sentry/conventions": "^0.16.0",
+        "@sentry/core": "10.70.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@cloudflare/workers-types": "^4.x",
+        "@hono/node-server": "^1.x || ^2.x",
+        "@sentry/bun": "10.70.0",
+        "@sentry/cloudflare": "10.70.0",
+        "@sentry/deno": "10.70.0",
+        "@sentry/node": "10.70.0",
+        "hono": "^4.x"
+      },
+      "peerDependenciesMeta": {
+        "@cloudflare/workers-types": {
+          "optional": true
+        },
+        "@hono/node-server": {
+          "optional": true
+        },
+        "@sentry/bun": {
+          "optional": true
+        },
+        "@sentry/cloudflare": {
+          "optional": true
+        },
+        "@sentry/deno": {
+          "optional": true
+        },
+        "@sentry/node": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@sentry/react": {
       "version": "10.70.0",
       "resolved": "https://registry.npmjs.org/@sentry/react/-/react-10.70.0.tgz",
@@ -13589,6 +13632,7 @@
         "@repo/shared": "*",
         "@sentry/cli": "3.6.2",
         "@sentry/cloudflare": "10.70.0",
+        "@sentry/hono": "10.70.0",
         "hono": "4.12.2",
         "zod": "4.3.6"
       },

--- a/package.json
+++ b/package.json
@@ -39,5 +39,14 @@
   "packageManager": "npm@11.10.1",
   "engines": {
     "node": "24.x"
+  },
+  "allowScripts": {
+    "@heroui/shared-utils@2.1.12": true,
+    "@sentry/cli@2.58.6": true,
+    "@sentry/cli@3.6.2": true,
+    "esbuild@0.27.3": true,
+    "fsevents@2.3.3": true,
+    "sharp@0.34.5": true,
+    "workerd@1.20260302.0": true
   }
 }

--- a/packages/api-handlers/package.json
+++ b/packages/api-handlers/package.json
@@ -20,6 +20,7 @@
     "@repo/shared": "*",
     "@sentry/cli": "3.6.2",
     "@sentry/cloudflare": "10.70.0",
+    "@sentry/hono": "10.70.0",
     "hono": "4.12.2",
     "zod": "4.3.6"
   },

--- a/packages/api-handlers/package.json
+++ b/packages/api-handlers/package.json
@@ -18,8 +18,8 @@
     "@ctrl/tinycolor": "4.2.0",
     "@hono/zod-validator": "0.7.6",
     "@repo/shared": "*",
-    "@sentry/cli": "3.2.2",
-    "@sentry/cloudflare": "10.39.0",
+    "@sentry/cli": "3.6.2",
+    "@sentry/cloudflare": "10.70.0",
     "hono": "4.12.2",
     "zod": "4.3.6"
   },

--- a/packages/api-handlers/src/server/__tests__/index.test.ts
+++ b/packages/api-handlers/src/server/__tests__/index.test.ts
@@ -1,7 +1,7 @@
 import { app, routes } from '@/server/index.js';
 
 vi.mock('hono/cors', () => ({
-    cors: vi.fn(),
+    cors: vi.fn(() => async (_c: unknown, next: () => Promise<void>) => next()),
 }));
 
 describe('API Server Configuration', () => {

--- a/packages/api-handlers/src/server/index.ts
+++ b/packages/api-handlers/src/server/index.ts
@@ -1,4 +1,4 @@
-import { withSentry } from '@sentry/cloudflare';
+import { sentry } from '@sentry/hono/cloudflare';
 import { Hono } from 'hono';
 import { env } from 'hono/adapter';
 import { cors } from 'hono/cors';
@@ -6,6 +6,14 @@ import { encodingApi } from '@/server/encoding.js';
 import { AppEnv } from '@/types.js';
 
 const honoApp = new Hono<AppEnv>().basePath('/api');
+
+honoApp.use(
+    sentry(honoApp, (sentryEnv) => ({
+        dsn: 'https://895c486a1e653f07201b20658156b954@o4508580787781632.ingest.us.sentry.io/4509040320970752',
+        tracesSampleRate: 1.0,
+        enabled: sentryEnv.APP_ENV !== 'local',
+    }))
+);
 
 honoApp.use(
     '*',
@@ -28,11 +36,4 @@ honoApp.notFound((c) => {
 
 export const routes = honoApp.route('/config', encodingApi);
 
-export const app = withSentry<Env>(
-    (sentryEnv) => ({
-        dsn: 'https://895c486a1e653f07201b20658156b954@o4508580787781632.ingest.us.sentry.io/4509040320970752',
-        tracesSampleRate: 1.0,
-        enabled: sentryEnv.APP_ENV !== 'local',
-    }),
-    honoApp
-);
+export const app = honoApp;

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -20,7 +20,7 @@
   },
   "dependencies": {
     "@ctrl/tinycolor": "4.2.0",
-    "@sentry/cli": "3.2.2",
+    "@sentry/cli": "3.6.2",
     "nanoid": "5.1.6",
     "react": "19.2.4",
     "zod": "4.3.6"


### PR DESCRIPTION
# Pull Request

## Description

Moves every Sentry package from 10.39.0 to 10.70.0 and replaces the deprecated `honoIntegration` code path with the dedicated `@sentry/hono` package.

Two commits, split so each half can be reverted independently:

**1. `chore: upgrade Sentry packages to 10.70.0`** — a pure dependency bump requiring no TypeScript changes. `@sentry/react` and `@sentry/cloudflare` 10.39.0 → 10.70.0, `@sentry/vite-plugin` 5.0.0 → 5.4.0, `@sentry/cli` 3.2.2 → 3.6.2. The root `allowScripts` keys were updated to match, including the transitive `@sentry/cli` copy that moved from 2.58.5 to 2.58.6 when `@sentry/vite-plugin` restructured onto `@sentry/bundler-plugins`. A stale `allowScripts` key fails silently, so the `sentry-cli` binary was verified post-install.

**2. `refactor: replace withSentry with @sentry/hono middleware`** — `@sentry/cloudflare` ships `honoIntegration()` as a default integration, deprecated as of 10.55.0 in favor of `@sentry/hono`. The `withSentry` wrapper around the Hono app becomes a `sentry()` middleware registered on it, first in the chain (ahead of `cors()`) and before route mounting, so handlers are wrapped at registration time. This gains route-parametrized transaction names and middleware spans.

`export const app` changes static type from `ExportedHandler<Env, unknown, unknown>` to the Hono instance itself. Both satisfy `ExportedHandler<Env>`, so `apps/api/src/index.ts` is unchanged. `export const routes` keeps a byte-identical type, so the `hc<ApiAppType>` client contract in `apps/web` is unaffected.

## Type of Change

- [x] Code refactoring or optimization

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Additional Context

### One test change, and why it was needed

`packages/api-handlers/src/server/__tests__/index.test.ts` mocked `hono/cors` as bare `cors: vi.fn()`, which returns `undefined` when called. Plain Hono tolerated registering `undefined` as a handler because nothing in that test ever invoked it. `@sentry/hono` wraps every handler in a span proxy at registration time, so `wrapMiddlewareWithSpan(undefined)` now throws on import.

The mock was simply unfaithful — real `cors()` always returns a middleware function — so it now returns a pass-through. No production code changed as a result, and this does not indicate a behavior change in the application.

### Verification

`sherif`, `build`, `check-types`, `lint`, and `test:ci` (200/200 across 18 files) all pass. The Worker was additionally probed under `wrangler dev`:

| Probe | Expected | Result |
| --- | --- | --- |
| `POST /api/config/decode` with bad payload | 400 from handler catch | 400 |
| `POST /api/config/decode` with `{}` | 400 from `zValidator` | 400 |
| `OPTIONS` preflight with `Origin` | `access-control-allow-origin` echoed | present |
| `GET /api/nope` | 200 via `notFound` → `ASSETS` | 200 |
| Console output | no sub-app ordering warning | absent |

The CORS probe is the important one, since `sentry()` now precedes `cors()` in the chain.

### Not verified

- **Sentry event delivery.** `APP_ENV=local` under `wrangler dev` and the config is `enabled: APP_ENV !== 'local'`, so the SDK is off locally. The probes prove the app works with the middleware installed, not that events arrive.
- **Route-parametrized transaction names.** The primary benefit of `@sentry/hono`, only observable in the Sentry UI after a deploy.
- **Source map upload with `@sentry/cli` 3.6.2.** Runs only under `build:with-sentry`, which needs `SENTRY_AUTH_TOKEN`.
- **The `@sentry/vite-plugin` 5.4.0 restructure.** Gated behind `WITH_SENTRY`, so the default build path never loads it.

### Expected metric shifts after deploy, not defects

- Session and crash-free-user metrics will move. 10.40.0 fixed session accounting so user id is consistently attached and the first soft navigation after pageload is no longer skipped. Alerts keyed to those metrics may fire.
- Bot traffic stops producing transactions. 10.44.0 skips `browserTracingIntegration` for bot user agents.
- The Worker bundle grows roughly 7 KB minified (2.7 KB gzipped) from `@sentry/hono`.
- React routing spans gain `url.template`, `url.path`, and `url.full` attributes as of 10.65.0.

No `CHANGELOG.md` entry: an SDK version bump is not user-facing under the project's changelog policy. `apps/api/wrangler.jsonc` `compatibility_flags` is deliberately unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
