### PR TITLE
feat: enable Sentry structured logs on the Worker

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -2,6 +2,7 @@
   "enabledPlugins": {
     "context7@claude-plugins-official": true,
     "superpowers@claude-plugins-official": true,
-    "playwright@claude-plugins-official": true
+    "playwright@claude-plugins-official": true,
+    "sentry@claude-plugins-official": true
   }
 }

--- a/apps/api/wrangler.jsonc
+++ b/apps/api/wrangler.jsonc
@@ -11,7 +11,18 @@
     "not_found_handling": "single-page-application"
   },
   "observability": {
-    "enabled": true,
-    "head_sampling_rate": 1
+    "enabled": false,
+    "head_sampling_rate": 1,
+    "logs": {
+      "enabled": true,
+      "head_sampling_rate": 1,
+      "persist": true,
+      "invocation_logs": true
+    },
+    "traces": {
+      "enabled": false,
+      "persist": true,
+      "head_sampling_rate": 1
+    }
   }
 }

--- a/docs/superpowers/plans/2026-08-11-sentry-worker-logs.md
+++ b/docs/superpowers/plans/2026-08-11-sentry-worker-logs.md
@@ -84,7 +84,7 @@ honoApp.use(
         dsn: 'https://895c486a1e653f07201b20658156b954@o4508580787781632.ingest.us.sentry.io/4509040320970752',
         tracesSampleRate: 1.0,
         enableLogs: true,
-        environment: sentryEnv.APP_ENV,
+        environment: sentryEnv.APP_ENV ?? 'production',
         enabled: sentryEnv.APP_ENV !== 'local',
     }))
 );
@@ -93,13 +93,13 @@ honoApp.use(
 Do not change the `dsn`, `tracesSampleRate`, or `enabled` lines. `enableLogs`
 defaults to `false`, which is the entire reason the Sentry Logs tab is empty.
 
-Non-blocking follow-up, not a code change: `APP_ENV` is not set anywhere in
-`.github/`, so its production value comes from the Cloudflare dashboard or is
-unset. Confirm the dashboard value so the production log filter is known. If it
-is unset, `environment: undefined` makes the SDK fall back to its own
-`production` default, which is exactly the current behavior, so this task is
-safe to land either way. Every span in the project today reports
-`environment: production`, which is consistent with both possibilities.
+Note on the fallback: events and logs do not treat an undefined `environment`
+the same way. Events receive the SDK's `DEFAULT_ENVIRONMENT` in `prepareEvent`,
+but the log path sets `sentry.environment` directly from the option through a
+helper guarded by `if (value && ...)`, so an undefined value means the attribute
+is absent from every log. `APP_ENV` is not set anywhere in `.github/`, so
+writing `?? 'production'` removes the dependency on a Cloudflare dashboard value
+that is invisible from the repository. It is a no-op when a value is supplied.
 
 - [ ] **Step 2: Typecheck**
 

--- a/docs/superpowers/plans/2026-08-11-sentry-worker-logs.md
+++ b/docs/superpowers/plans/2026-08-11-sentry-worker-logs.md
@@ -1,0 +1,489 @@
+# Sentry Worker Structured Logs Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Turn on Sentry structured logs for the Cloudflare Worker and emit an
+error log from the two encode/decode failure paths that currently vanish into a
+400 response.
+
+**Architecture:** Two properties are added to the existing `sentry()` middleware
+options in the Worker's Hono app, which opens the log transport and tags the
+environment. The two `catch` blocks in the encoding routes then call
+`logger.error` before returning their existing 400 response. Response bodies do
+not change, so the typed client contract consumed by `apps/web` is untouched.
+
+**Tech Stack:** TypeScript (strict, `nodenext`), Hono, `@sentry/cloudflare`
+10.70.0, `@sentry/hono` 10.70.0, Vitest, Wrangler, npm workspaces, Turborepo.
+
+**Spec:** `docs/superpowers/specs/2026-08-11-sentry-worker-logs-design.md`
+
+**Branch:** `feat/sentry-worker-logs` (already created; the spec is committed on it)
+
+## Global Constraints
+
+- All work happens inside `packages/api-handlers`. No new files, no new
+  dependencies. `@sentry/cloudflare@10.70.0` is already a direct dependency.
+- **`packages/api-handlers` has no `check-types` script.** The root
+  `npm run check-types` and the husky pre-commit hook therefore skip this
+  workspace entirely. Type errors surface only on build. Every task that
+  changes TypeScript here must run
+  `npm run build --workspace packages/api-handlers` as its typecheck gate.
+- TypeScript is strict. No `any`. The existing `(error as Error)?.` casts in
+  these catch blocks are the established pattern; match them.
+- Do not hand-order imports. `@trivago/prettier-plugin-sort-imports` owns
+  ordering, with all third-party modules in one alphabetical group. A new
+  `@sentry/cloudflare` import sorts after `@repo/shared/...` and before `hono`
+  (source) or `vitest` (test).
+- `moduleResolution` is `nodenext`. Intra-package imports need an explicit
+  `.js` extension; bare package specifiers like `@sentry/cloudflare` do not.
+- No `CHANGELOG.md` entry. This is observability, not a user-facing change.
+- Never commit `apps/api/.dev.vars`. It is gitignored
+  (`apps/api/.gitignore:22`) and must be reverted to `APP_ENV=local` after
+  Task 4.
+- The working tree has unrelated uncommitted changes to `.claude/settings.json`
+  and `apps/api/wrangler.jsonc`. Leave them alone. Stage files by name only.
+- Commit trailer: `Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>`
+
+## File Structure
+
+| File | Responsibility | Change |
+| --- | --- | --- |
+| `packages/api-handlers/src/server/index.ts` | Hono app assembly and Sentry middleware registration | Modify: add `enableLogs` and `environment` to the `sentry()` options callback (lines 11-15) |
+| `packages/api-handlers/src/server/encoding.ts` | `/encode` and `/decode` routes | Modify: add `logger` import; add a `logger.error` call to each of the two catch blocks (lines 82-84 and 99-101) |
+| `packages/api-handlers/src/server/__tests__/encoding.test.ts` | Route-level tests for the above | Modify: mock `@sentry/cloudflare`; assert `logger.error` in the two existing error-path tests (lines 82-98 and 123-141) |
+
+No files are created. No test file is created; both failure paths already have
+tests that force the rejection, and those tests gain assertions.
+
+---
+
+### Task 1: Enable logs and tag the environment
+
+Opens the Sentry log transport on the Worker and stops every event from being
+reported as `production`. Nothing emits a log yet, so this task's deliverable is
+verified by "still builds, still green", not by a new assertion. The live proof
+comes in Task 4.
+
+**Files:**
+- Modify: `packages/api-handlers/src/server/index.ts:11-15`
+
+**Interfaces:**
+- Consumes: nothing from earlier tasks.
+- Produces: an initialized Sentry client with `enableLogs: true`, which is the
+  precondition for the `logger.error` calls in Tasks 2 and 3 producing anything
+  at runtime. No exported symbols change.
+
+- [ ] **Step 1: Add the two options**
+
+In `packages/api-handlers/src/server/index.ts`, replace the options callback so
+it reads exactly:
+
+```typescript
+honoApp.use(
+    sentry(honoApp, (sentryEnv) => ({
+        dsn: 'https://895c486a1e653f07201b20658156b954@o4508580787781632.ingest.us.sentry.io/4509040320970752',
+        tracesSampleRate: 1.0,
+        enableLogs: true,
+        environment: sentryEnv.APP_ENV,
+        enabled: sentryEnv.APP_ENV !== 'local',
+    }))
+);
+```
+
+Do not change the `dsn`, `tracesSampleRate`, or `enabled` lines. `enableLogs`
+defaults to `false`, which is the entire reason the Sentry Logs tab is empty.
+
+Non-blocking follow-up, not a code change: `APP_ENV` is not set anywhere in
+`.github/`, so its production value comes from the Cloudflare dashboard or is
+unset. Confirm the dashboard value so the production log filter is known. If it
+is unset, `environment: undefined` makes the SDK fall back to its own
+`production` default, which is exactly the current behavior, so this task is
+safe to land either way. Every span in the project today reports
+`environment: production`, which is consistent with both possibilities.
+
+- [ ] **Step 2: Typecheck**
+
+Run: `npm run build --workspace packages/api-handlers`
+Expected: exits 0 with no output beyond the `tsc && tsc-alias` banner. This is
+the only typecheck that covers this workspace, and it compiles the test files
+too, so it also catches type errors in the assertions added by Tasks 2 and 3.
+
+- [ ] **Step 3: Confirm no regression**
+
+Run: `npx vitest run packages/api-handlers/src/server/__tests__/index.test.ts`
+Expected: PASS. This test only asserts that `app` and `routes` are defined; it
+is a smoke check that the middleware still registers.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add packages/api-handlers/src/server/index.ts
+git commit -m "$(cat <<'EOF'
+feat: enable Sentry structured logs on the Worker
+
+enableLogs defaults to false, so the Sentry Logs product has never
+received anything from this Worker. Also sets environment from APP_ENV,
+which previously fell through to the SDK default of production for every
+event including local runs.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+### Task 2: Log encode failures
+
+`POST /api/config/encode` catches every error and returns a 400. Because the
+handler returns normally, the Sentry Hono middleware never sees an exception, so
+the failure produces no issue, no log, and no trace error. This task makes it
+emit a log.
+
+**Files:**
+- Modify: `packages/api-handlers/src/server/encoding.ts` (import block, and the catch at lines 82-84)
+- Test: `packages/api-handlers/src/server/__tests__/encoding.test.ts` (import block, module mocks, and the test at lines 82-98)
+
+**Interfaces:**
+- Consumes: `enableLogs: true` from Task 1.
+- Produces: the `vi.mock('@sentry/cloudflare', ...)` block and the `logger`
+  import in the test file, both of which Task 3 reuses as-is. The runtime
+  signature relied on is `logger.error(message: string, attributes?: Record<string, unknown>): void`.
+
+- [ ] **Step 1: Mock the Sentry module in the test file**
+
+In `packages/api-handlers/src/server/__tests__/encoding.test.ts`, add the
+`logger` import to the existing import block. Prettier will place it after
+`@repo/shared/validators/config` and before `vitest`:
+
+```typescript
+import { logger } from '@sentry/cloudflare';
+```
+
+Then add this mock alongside the two `vi.mock` calls that already exist near the
+top of the file (after the `@/utils/encoding` mock and the
+`@repo/shared/utils/colors` mock):
+
+```typescript
+vi.mock('@sentry/cloudflare', () => ({
+    logger: {
+        error: vi.fn(),
+    },
+}));
+```
+
+This mock is safe to scope to the whole module: this test imports `encodingApi`
+from `@/server/encoding.js` directly rather than the assembled server, so it
+does not disturb the `@sentry/hono/cloudflare` import in
+`packages/api-handlers/src/server/index.ts`. The existing
+`vi.resetAllMocks()` in `beforeEach` clears the call record between tests, which
+is what these assertions depend on.
+
+- [ ] **Step 2: Add the failing assertion**
+
+In the existing `should handle errors during encoding` test, add one assertion
+at the end. The test already builds `mockError` as `new Error('Encoding failed')`
+and rejects `encodeConfig` with it; leave all of that alone. The test becomes:
+
+```typescript
+        it('should handle errors during encoding', async () => {
+            const mockError = new Error('Encoding failed');
+            vi.mocked(encodeConfig).mockRejectedValue(mockError);
+
+            const response = await encodingApi.request('/encode', {
+                method: 'POST',
+                headers: {
+                    'Content-Type': 'application/json',
+                },
+                body: JSON.stringify(mockFormData),
+            });
+            const responseData = await response.json();
+
+            expect(response.status).toBe(400);
+            expect(responseData).toEqual({ error: mockError.message });
+            expect(vi.mocked(logger.error)).toHaveBeenCalledWith('Failed to encode config', {
+                error: 'Encoding failed',
+            });
+        });
+```
+
+- [ ] **Step 3: Run the test to verify it fails**
+
+Run: `npx vitest run packages/api-handlers/src/server/__tests__/encoding.test.ts -t "should handle errors during encoding"`
+Expected: FAIL, reporting that the `logger.error` mock received 0 calls.
+
+- [ ] **Step 4: Implement**
+
+In `packages/api-handlers/src/server/encoding.ts`, add the import. Prettier will
+place it after `@repo/shared/validators/config` and before `hono`:
+
+```typescript
+import { logger } from '@sentry/cloudflare';
+```
+
+Then replace the encode catch block. It is the one whose fallback string is
+`'Error encoding config'`:
+
+```typescript
+        } catch (error) {
+            logger.error('Failed to encode config', {
+                error: (error as Error)?.message,
+            });
+            return c.json({ error: (error as Error)?.message ?? 'Error encoding config' }, 400);
+        }
+```
+
+Leave the `return c.json(...)` line byte-identical. The response body is part of
+the typed client contract.
+
+- [ ] **Step 5: Run the test to verify it passes**
+
+Run: `npx vitest run packages/api-handlers/src/server/__tests__/encoding.test.ts`
+Expected: PASS, all 6 tests in the file.
+
+- [ ] **Step 6: Typecheck**
+
+Run: `npm run build --workspace packages/api-handlers`
+Expected: exits 0. Remember the pre-commit hook does not typecheck this
+workspace, so this step is the gate.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add packages/api-handlers/src/server/encoding.ts packages/api-handlers/src/server/__tests__/encoding.test.ts
+git commit -m "$(cat <<'EOF'
+feat: log encode failures to Sentry
+
+The encode route converts every thrown error into a 400 response, so the
+Sentry Hono middleware never observes an exception and the failure is
+invisible. Emit an error log before returning.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+### Task 3: Log decode failures, including the wrapped cause
+
+Same gap on `POST /api/config/decode`, with one extra wrinkle.
+`decodeConfig` (`packages/api-handlers/src/utils/encoding.ts:33`) rethrows every
+internal failure as `new Error('Invalid config', { cause: error })`, so
+`(error as Error).message` is the constant string `"Invalid config"` no matter
+what actually went wrong. A log carrying only that message says nothing useful.
+The real failure lives on `cause`.
+
+**Files:**
+- Modify: `packages/api-handlers/src/server/encoding.ts` (the catch at lines 99-101)
+- Test: `packages/api-handlers/src/server/__tests__/encoding.test.ts` (the test at lines 123-141)
+
+**Interfaces:**
+- Consumes: the `vi.mock('@sentry/cloudflare', ...)` block and the `logger`
+  import added to the test file in Task 2, and the `logger` import added to
+  `encoding.ts` in Task 2. Do not add either a second time.
+- Produces: nothing later tasks depend on.
+
+- [ ] **Step 1: Give the mock error a cause and add the failing assertion**
+
+In the existing `should handle errors during decoding` test, change `mockError`
+so it carries the cause `decodeConfig` really attaches, and add one assertion.
+The test becomes:
+
+```typescript
+        it('should handle errors during decoding', async () => {
+            const mockRequestData = {
+                encodedConfig: 'invalid-encoded-config',
+            };
+            const mockError = new Error('Invalid config', {
+                cause: new Error('Unsupported config encoding version'),
+            });
+            vi.mocked(decodeConfig).mockRejectedValue(mockError);
+
+            const response = await encodingApi.request('/decode', {
+                method: 'POST',
+                headers: {
+                    'Content-Type': 'application/json',
+                },
+                body: JSON.stringify(mockRequestData),
+            });
+            const responseData = await response.json();
+
+            expect(response.status).toBe(400);
+            expect(responseData).toEqual({ error: mockError.message });
+            expect(vi.mocked(logger.error)).toHaveBeenCalledWith('Failed to decode config', {
+                error: 'Invalid config',
+                cause: 'Unsupported config encoding version',
+            });
+        });
+```
+
+Adding the cause is what exercises the new attribute. The existing
+`expect(responseData).toEqual({ error: mockError.message })` assertion still
+holds, because `message` is still `'Invalid config'`.
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `npx vitest run packages/api-handlers/src/server/__tests__/encoding.test.ts -t "should handle errors during decoding"`
+Expected: FAIL, reporting that the `logger.error` mock received 0 calls.
+
+- [ ] **Step 3: Implement**
+
+In `packages/api-handlers/src/server/encoding.ts`, replace the decode catch
+block. It is the one whose fallback string is `'Error decoding config'`:
+
+```typescript
+        } catch (error) {
+            const cause = (error as Error)?.cause;
+            logger.error('Failed to decode config', {
+                error: (error as Error)?.message,
+                ...(cause instanceof Error ? { cause: cause.message } : {}),
+            });
+            return c.json({ error: (error as Error)?.message ?? 'Error decoding config' }, 400);
+        }
+```
+
+The conditional spread is deliberate and must not be simplified to
+`cause: String(cause)`. `String(undefined)` produces the literal string
+`"undefined"`, which would ship a meaningless attribute to Sentry whenever an
+error carries no cause. Omitting the key is unambiguous and does not depend on
+how the SDK treats `undefined` attribute values. In practice `decodeConfig`
+always attaches an `Error` cause; the guard covers something other than
+`decodeConfig` throwing inside the `try`.
+
+Do not add the `logger` import again. Task 2 already added it.
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `npx vitest run packages/api-handlers/src/server/__tests__/encoding.test.ts`
+Expected: PASS, all 6 tests in the file.
+
+- [ ] **Step 5: Typecheck**
+
+Run: `npm run build --workspace packages/api-handlers`
+Expected: exits 0.
+
+- [ ] **Step 6: Run the full suite**
+
+Run: `npm run test:ci`
+Expected: PASS with exactly 200 tests across 18 files. That is the verified
+baseline measured on this branch before implementation began, and this plan adds
+assertions to existing tests rather than new test cases, so the count must not
+move. A different count means something was added or lost by accident.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add packages/api-handlers/src/server/encoding.ts packages/api-handlers/src/server/__tests__/encoding.test.ts
+git commit -m "$(cat <<'EOF'
+feat: log decode failures to Sentry
+
+decodeConfig rethrows everything as Error('Invalid config', { cause }),
+so the message alone identifies nothing. Log the cause message alongside
+it, omitting the attribute when there is no Error cause.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+### Task 4: Live local verification
+
+The unit tests prove `logger.error` is called. They do not prove Sentry ingests
+anything, which is the exact thing that was broken. This task is the only
+end-to-end proof, and it is required before merging.
+
+It matters because production will not demonstrate this for you. A 90 day span
+query over these two routes returned 12 completed `http.server` spans, every one
+HTTP 200. Neither catch block has fired in production in that window, so after
+merge the Logs tab stays empty until something genuinely breaks.
+
+Nothing in this task is committed.
+
+**Files:**
+- Modify temporarily, never commit: `apps/api/.dev.vars`
+
+**Interfaces:**
+- Consumes: all three preceding tasks, merged into the working tree.
+- Produces: nothing. This is a verification gate.
+
+- [ ] **Step 1: Lift the local kill switch**
+
+The SDK is disabled locally by `enabled: sentryEnv.APP_ENV !== 'local'`, and
+`apps/api/.dev.vars` contains exactly `APP_ENV=local`. Edit that file to read:
+
+```
+APP_ENV=development
+```
+
+The file is gitignored, so this cannot be committed by accident. It still must
+be reverted in Step 5.
+
+- [ ] **Step 2: Start the Worker**
+
+Run: `npm run dev --workspace apps/api`
+Expected: wrangler starts and serves on `http://localhost:8787`.
+
+- [ ] **Step 3: Trigger the decode catch block**
+
+From a second shell:
+
+```bash
+curl -X POST localhost:8787/api/config/decode \
+  -H 'Content-Type: application/json' \
+  -d '{"encodedConfig":"garbage"}'
+```
+
+Expected: HTTP 400 with body `{"error":"Invalid config"}`. The payload fails the
+`v4.` version prefix check inside `decodeConfig`, which is what routes it into
+the catch block.
+
+Use `curl`, not the SPA. Moving `APP_ENV` off `local` also changes the CORS
+origin predicate at `packages/api-handlers/src/server/index.ts:23`, which admits
+any origin only when `APP_ENV === 'local'`. A browser request from the Vite dev
+server would be rejected. `curl` sends no `Origin` header, so the check does not
+apply.
+
+- [ ] **Step 4: Confirm the log reached Sentry**
+
+Open the Logs view for the `wits-api` project in the `brian-sokol` org and
+filter on `environment:development`:
+
+https://brian-sokol.sentry.io/explore/logs/?logsQuery=&project=4509040320970752&statsPeriod=24h
+
+Expected: a `Failed to decode config` entry at error severity, with an `error`
+attribute of `Invalid config` and a `cause` attribute naming the real underlying
+failure.
+
+If nothing arrives, add `debug: true` to the `sentry()` options in
+`packages/api-handlers/src/server/index.ts` temporarily and re-run. A Worker
+flushes Sentry envelopes through `waitUntil`, and a silent drop during flush is
+the usual failure mode. Remove `debug: true` before committing anything.
+
+- [ ] **Step 5: Revert the kill switch**
+
+Edit `apps/api/.dev.vars` back to:
+
+```
+APP_ENV=local
+```
+
+Run: `git status --short`
+Expected: `apps/api/.dev.vars` does not appear (it is gitignored). The only
+entries should be the pre-existing unrelated changes to `.claude/settings.json`
+and `apps/api/wrangler.jsonc`. If any file under `packages/api-handlers` is
+still dirty, a debug edit was left behind; revert it.
+
+---
+
+## Done when
+
+- `enableLogs: true` and `environment` are set on the Worker Sentry init.
+- Both encode and decode catch blocks call `logger.error` before returning 400.
+- Both existing error-path tests assert the call; `npm run test:ci` is green.
+- `npm run build --workspace packages/api-handlers` exits 0.
+- A `Failed to decode config` log has been observed in Sentry under
+  `environment:development` from a local run.
+- `apps/api/.dev.vars` reads `APP_ENV=local`, and no debug edits remain.

--- a/docs/superpowers/specs/2026-08-11-sentry-worker-logs-design.md
+++ b/docs/superpowers/specs/2026-08-11-sentry-worker-logs-design.md
@@ -135,7 +135,7 @@ honoApp.use(
         dsn: 'https://895c486a1e653f07201b20658156b954@o4508580787781632.ingest.us.sentry.io/4509040320970752',
         tracesSampleRate: 1.0,
         enableLogs: true,
-        environment: sentryEnv.APP_ENV,
+        environment: sentryEnv.APP_ENV ?? 'production',
         enabled: sentryEnv.APP_ENV !== 'local',
     }))
 );
@@ -147,10 +147,17 @@ indistinguishable in the Sentry UI from a log emitted by real traffic. With it,
 the live test in the verification section below is filterable and disposable.
 
 `APP_ENV` is not set anywhere in `.github/`, so its production value comes from
-the Cloudflare dashboard or is unset. If unset, `environment: undefined` makes
-the SDK fall back to its own `production` default, which is the current
-behavior. The change is safe either way. Confirm the dashboard value so the
-production filter is known.
+the Cloudflare dashboard or is unset. Events and logs do not treat an undefined
+`environment` the same way, which is why the fallback is written explicitly.
+Events receive the SDK's `DEFAULT_ENVIRONMENT` in `prepareEvent`. Logs never go
+through `prepareEvent`; the log path sets `sentry.environment` directly from the
+option through a helper guarded by `if (value && ...)`, so an undefined value
+means the attribute is absent from every log. Production logs would then carry
+no environment while spans from the same client report `production`, and any
+alert filtered on `environment:production` would miss them. Writing
+`sentryEnv.APP_ENV ?? 'production'` is a no-op when the dashboard supplies a
+value and removes the dependency on dashboard state that is invisible from the
+repository.
 
 ### Change 2: emit from the swallowed catch blocks
 

--- a/docs/superpowers/specs/2026-08-11-sentry-worker-logs-design.md
+++ b/docs/superpowers/specs/2026-08-11-sentry-worker-logs-design.md
@@ -1,0 +1,290 @@
+# Sentry Structured Logs for the Cloudflare Worker
+
+Date: 2026-08-11
+Branch: `feat/sentry-worker-logs`
+
+## Context
+
+The Logs tab of the Sentry project is empty. Errors and traces arrive normally.
+This followed the 10.39.0 to 10.70.0 upgrade in #33, which made the upgrade look
+like the cause. It is not.
+
+`enableLogs` is a top level `init` option that defaults to `false`. In the
+installed SDK this is declared at
+`node_modules/@sentry/core/build/types/types/options.d.ts:530`:
+
+```typescript
+/**
+ * If logs support should be enabled.
+ *
+ * @default false
+ */
+enableLogs?: boolean;
+```
+
+The older `_experiments.enableLogs` form still exists at line 421 of the same
+file, marked `@deprecated Use the top level enableLogs option instead`.
+
+Neither `init` call in this repository has ever set either form:
+
+- `apps/web/src/main.tsx:9`, the browser init
+- `packages/api-handlers/src/server/index.ts:11`, the Worker init
+
+Sentry's Logs product has therefore received nothing since it shipped. The
+upgrade changed no behavior here.
+
+Enabling the option is necessary but not sufficient. It opens the transport; it
+does not produce logs. Logs come from explicit `logger.*` calls or from
+`consoleLoggingIntegration()`, which forwards `console.*` output. The Worker
+source tree (`packages/api-handlers/src`, excluding `__tests__`) contains zero
+`console.*` calls, so flipping the flag alone would leave the Logs tab exactly
+as empty as it is now.
+
+## Goals
+
+1. Enable Sentry structured logs on the Cloudflare Worker.
+2. Emit logs from the two failure paths that are currently invisible to Sentry.
+3. Make the change verifiable locally, against the real Sentry project, without
+   polluting production data.
+
+## Non-goals
+
+- The browser side (`apps/web/src/main.tsx`). Worker only, by decision.
+- `consoleLoggingIntegration()`. See "Considered and rejected".
+- The uncommitted `apps/api/wrangler.jsonc` observability edit in the working
+  tree. That is Cloudflare Workers Logs, a separate system from Sentry.
+- A `CHANGELOG.md` entry. This is observability, not a user facing change.
+- The `apps/web/src/components/error-boundary.tsx:43` TODO about wiring the
+  React error boundary into Sentry. Still open, still out of scope.
+
+## Current integration surface
+
+| Location                                              | State                                               |
+| ----------------------------------------------------- | --------------------------------------------------- |
+| `packages/api-handlers/src/server/index.ts:11`        | `sentry()` middleware, no `enableLogs`, no `environment` |
+| `packages/api-handlers/src/server/encoding.ts:82`     | encode failure swallowed into a 400 response        |
+| `packages/api-handlers/src/server/encoding.ts:99`     | decode failure swallowed into a 400 response        |
+| `apps/api/.dev.vars`                                  | `APP_ENV=local`, gitignored via `apps/api/.gitignore:22` |
+| `packages/api-handlers/package.json`                  | `@sentry/cloudflare@10.70.0` is already a direct dependency |
+
+### Why the two catch blocks matter
+
+Both routes convert a thrown error into a normal `400` JSON response:
+
+```typescript
+} catch (error) {
+    return c.json({ error: (error as Error)?.message ?? 'Error decoding config' }, 400);
+}
+```
+
+Because the handler returns normally, the Sentry Hono middleware never observes
+an exception. These failures produce no issue, no log, and no trace error today.
+They are entirely invisible.
+
+## Design
+
+Three file edits, all inside `packages/api-handlers`: the server init, the
+encoding routes, and their existing test. No new files, no new dependencies.
+
+### Change 1: enable logs and tag the environment
+
+`packages/api-handlers/src/server/index.ts`, two properties added to the
+existing options callback:
+
+```typescript
+honoApp.use(
+    sentry(honoApp, (sentryEnv) => ({
+        dsn: 'https://895c486a1e653f07201b20658156b954@o4508580787781632.ingest.us.sentry.io/4509040320970752',
+        tracesSampleRate: 1.0,
+        enableLogs: true,
+        environment: sentryEnv.APP_ENV,
+        enabled: sentryEnv.APP_ENV !== 'local',
+    }))
+);
+```
+
+`environment` exists to make local verification safe. Without it, every event
+the SDK sends defaults to `production`, so a log emitted from a laptop is
+indistinguishable in the Sentry UI from a log emitted by real traffic. With it,
+the live test in the verification section below is filterable and disposable.
+
+`APP_ENV` is not set anywhere in `.github/`, so its production value comes from
+the Cloudflare dashboard or is unset. If unset, `environment: undefined` makes
+the SDK fall back to its own `production` default, which is the current
+behavior. The change is safe either way. Confirm the dashboard value so the
+production filter is known.
+
+### Change 2: emit from the swallowed catch blocks
+
+`packages/api-handlers/src/server/encoding.ts` gains one import:
+
+```typescript
+import { logger } from '@sentry/cloudflare';
+```
+
+`@sentry/cloudflare@10.70.0` is already a direct dependency of this workspace.
+`logger` is re-exported from `@sentry/core`; its runtime shape is an object
+carrying `fmt`, `debug`, `error`, `fatal`, `info`, `trace`, and `warn`. The
+signature is `logger.error(message, attributes?)`. Import placement is left to
+`@trivago/prettier-plugin-sort-imports`.
+
+The encode catch block:
+
+```typescript
+} catch (error) {
+    logger.error('Failed to encode config', {
+        error: (error as Error)?.message,
+    });
+    return c.json({ error: (error as Error)?.message ?? 'Error encoding config' }, 400);
+}
+```
+
+The decode catch block additionally records `cause`:
+
+```typescript
+} catch (error) {
+    const cause = (error as Error)?.cause;
+    logger.error('Failed to decode config', {
+        error: (error as Error)?.message,
+        ...(cause instanceof Error ? { cause: cause.message } : {}),
+    });
+    return c.json({ error: (error as Error)?.message ?? 'Error decoding config' }, 400);
+}
+```
+
+The asymmetry is deliberate. `decodeConfig`
+(`packages/api-handlers/src/utils/encoding.ts:33`) rethrows every internal
+failure as `new Error('Invalid config', { cause: error })`, so
+`(error as Error).message` is the constant string `"Invalid config"` regardless
+of what actually went wrong. A log carrying only that message conveys no
+information beyond the fact that a decode failed. The real failure lives on
+`cause`. `encodeConfig` performs no such wrapping, so its message is already
+the original one and no `cause` line is warranted.
+
+The conditional spread, rather than a plain `String(cause)`, exists because
+`String(undefined)` produces the literal string `"undefined"`, which would ship
+a meaningless attribute to Sentry on any error that carries no cause. Omitting
+the key is unambiguous and does not depend on how the SDK happens to treat
+`undefined` attribute values. In practice `decodeConfig` always attaches an
+`Error` cause, so the attribute is present on every log this block emits; the
+guard covers the case where something other than `decodeConfig` throws inside
+the `try`.
+
+Response bodies are unchanged in both blocks, so the `hc<ApiAppType>` client
+contract consumed by `apps/web` is unaffected.
+
+### Change 3: assert the calls in the existing tests
+
+`packages/api-handlers/src/server/__tests__/encoding.test.ts` already covers
+both failure paths and already forces the rejection:
+
+- `should handle errors during encoding` at line 82
+- `should handle errors during decoding` at line 123
+
+No new test file. Both gain an explicit assertion, backed by a module mock at
+the top of the file alongside the existing `vi.mock` calls:
+
+```typescript
+vi.mock('@sentry/cloudflare', () => ({
+    logger: {
+        error: vi.fn(),
+    },
+}));
+```
+
+The test file imports `logger` from `@sentry/cloudflare` alongside its existing
+imports in order to assert against it.
+
+In the encoding test, whose `mockError` is `new Error('Encoding failed')`:
+
+```typescript
+expect(logger.error).toHaveBeenCalledWith('Failed to encode config', {
+    error: 'Encoding failed',
+});
+```
+
+In the decoding test, whose `mockError` changes from `new Error('Invalid config')`
+to carry the cause that `decodeConfig` really attaches:
+
+```typescript
+const mockError = new Error('Invalid config', {
+    cause: new Error('Unsupported config encoding version'),
+});
+
+expect(logger.error).toHaveBeenCalledWith('Failed to decode config', {
+    error: 'Invalid config',
+    cause: 'Unsupported config encoding version',
+});
+```
+
+Adding the cause to that mock makes it faithful to what `decodeConfig` throws
+and is what exercises the `cause` attribute. The test's existing
+`expect(responseData).toEqual({ error: mockError.message })` assertion is
+unaffected, since `message` is still `'Invalid config'`.
+
+The mock is contained: this test imports `encodingApi` from
+`@/server/encoding.js` directly rather than the assembled server, so mocking
+`@sentry/cloudflare` here does not disturb the `@sentry/hono/cloudflare` import
+in `packages/api-handlers/src/server/index.ts` or its own test file. The
+existing `vi.resetAllMocks()` in `beforeEach` is compatible, since these
+assertions check call records rather than implementations.
+
+## Local verification
+
+Run once, by hand, before merging. Nothing here is committed.
+
+The SDK is disabled locally by `enabled: sentryEnv.APP_ENV !== 'local'`, and
+`apps/api/.dev.vars` contains exactly `APP_ENV=local`. That file is gitignored
+(`apps/api/.gitignore:22`), so editing it carries no risk of being committed.
+
+1. Edit `apps/api/.dev.vars`, changing `APP_ENV=local` to `APP_ENV=development`.
+2. Start the Worker: `npm run dev --workspace apps/api`.
+3. Trigger the decode catch block with a payload that fails the `v4.` version
+   check:
+
+   ```bash
+   curl -X POST localhost:8787/api/config/decode \
+     -H 'Content-Type: application/json' \
+     -d '{"encodedConfig":"garbage"}'
+   ```
+
+   Expect a `400` with `{"error":"Invalid config"}`.
+
+4. In Sentry, open the Logs tab and filter on `environment:development`. Expect
+   a `Failed to decode config` entry whose `cause` attribute names the real
+   underlying failure.
+5. Revert `apps/api/.dev.vars` to `APP_ENV=local`.
+
+Two constraints on this procedure:
+
+- Use `curl`, not the SPA. Moving `APP_ENV` off `local` also changes the CORS
+  origin check at `packages/api-handlers/src/server/index.ts:23`, which admits
+  any origin only when `APP_ENV === 'local'`. A browser request from the Vite
+  dev server would be rejected. `curl` sends no `Origin` header, so the check
+  does not apply.
+- If nothing arrives, add `debug: true` to the init temporarily to surface SDK
+  output in the wrangler console. A Worker flushes Sentry envelopes through
+  `waitUntil`, and a silent drop during flush is the usual failure mode.
+
+Automated verification is the existing suite: `npm run test` for the full run,
+plus the `check-types`, `sherif`, and `lint-staged` steps the pre-commit hook
+already enforces.
+
+## Considered and rejected
+
+**`consoleLoggingIntegration()`.** Forwards `console.*` calls to Sentry as
+structured logs with no call site changes. Rejected because the Worker source
+emits no `console.*` calls at all, so it would forward nothing and the Logs tab
+would stay empty. It remains a reasonable future addition once console calls
+exist.
+
+**`captureException` instead of `logger.error`.** Would surface these failures
+as Sentry issues rather than logs. Defensible, and arguably right for the encode
+path, where a failure is genuinely unexpected. Rejected for now because the
+stated goal is populating the Logs product, and a deliberately handled 400 is
+log shaped rather than issue shaped. Revisit if these turn out to fire often
+enough to warrant alerting.
+
+**A separate Sentry project for local development.** The cleanest isolation for
+the live test, but it requires new infrastructure to solve a problem that the
+`environment` tag already solves adequately.

--- a/docs/superpowers/specs/2026-08-11-sentry-worker-logs-design.md
+++ b/docs/superpowers/specs/2026-08-11-sentry-worker-logs-design.md
@@ -40,6 +40,30 @@ source tree (`packages/api-handlers/src`, excluding `__tests__`) contains zero
 `console.*` calls, so flipping the flag alone would leave the Logs tab exactly
 as empty as it is now.
 
+### Empirical confirmation
+
+Queried against the `brian-sokol` Sentry organization on 2026-08-11:
+
+| Dataset  | Project    | Window | Result                                    |
+| -------- | ---------- | ------ | ----------------------------------------- |
+| `logs`   | `wits-api` | 90d    | no results                                |
+| `logs`   | `wits-web` | 90d    | no results                                |
+| `spans`  | `wits-api` | 90d    | populated and current, latest 2026-08-12T03:28Z |
+| `errors` | `wits-api` | 90d    | no results                                |
+
+The span traffic rules out the transport, the DSN, and the `enabled` gate as
+possible causes. Logs is the only empty dataset while the very same SDK instance
+reports spans normally, which is precisely the signature of `enableLogs` being
+unset. The empty `errors` dataset is not a second symptom; nothing in the Worker
+has thrown, for the reason given under "Why the two catch blocks matter".
+
+Two incidental confirmations from the same data. The recent spans include
+`middleware.hono` entries, so the `@sentry/hono` adoption from #33 is live and
+working in production. And every span carries `environment: production`, which
+confirms that the currently unset `environment` option falls through to the SDK
+default and that a local test would otherwise be indistinguishable from real
+traffic.
+
 ## Goals
 
 1. Enable Sentry structured logs on the Cloudflare Worker.
@@ -80,6 +104,20 @@ Both routes convert a thrown error into a normal `400` JSON response:
 Because the handler returns normally, the Sentry Hono middleware never observes
 an exception. These failures produce no issue, no log, and no trace error today.
 They are entirely invisible.
+
+They are also, at present, rare. A 90 day span query scoped to
+`POST /api/config/decode` and `POST /api/config/encode` returns 12 completed
+`http.server` spans, every one of them HTTP 200. Neither catch block has fired
+in production within that window.
+
+This is worth stating plainly because it sets expectations for the outcome.
+Instrumenting these blocks is justified by the fact that a failure today would
+be silent, not by any current volume of failures. The practical consequence is
+that this change will not, by itself, put anything in the production Logs tab.
+The local live test described below is the only pre-merge proof that the pipe
+works end to end, and after merge the Logs tab will stay empty until something
+genuinely breaks. That is the correct behavior for error level logging, not a
+sign the change failed.
 
 ## Design
 

--- a/packages/api-handlers/src/server/__tests__/encoding.test.ts
+++ b/packages/api-handlers/src/server/__tests__/encoding.test.ts
@@ -65,6 +65,7 @@ describe('encodingApi', () => {
             expect(response.status).toBe(200);
             expect(responseData).toEqual({ encodedConfig: 'v4.encoded-config-string' });
             expect(encodeConfig).toHaveBeenCalled();
+            expect(logger.error).not.toHaveBeenCalled();
         });
 
         it('should handle single color background', async () => {
@@ -127,6 +128,7 @@ describe('encodingApi', () => {
             expect(response.status).toBe(200);
             expect(responseData).toEqual(mockDecodedConfig);
             expect(decodeConfig).toHaveBeenCalledWith('v4.encoded-config-string');
+            expect(logger.error).not.toHaveBeenCalled();
         });
 
         it('should handle errors during decoding', async () => {

--- a/packages/api-handlers/src/server/__tests__/encoding.test.ts
+++ b/packages/api-handlers/src/server/__tests__/encoding.test.ts
@@ -133,7 +133,9 @@ describe('encodingApi', () => {
             const mockRequestData = {
                 encodedConfig: 'invalid-encoded-config',
             };
-            const mockError = new Error('Invalid config');
+            const mockError = new Error('Invalid config', {
+                cause: new Error('Unsupported config encoding version'),
+            });
             vi.mocked(decodeConfig).mockRejectedValue(mockError);
 
             const response = await encodingApi.request('/decode', {
@@ -147,6 +149,10 @@ describe('encodingApi', () => {
 
             expect(response.status).toBe(400);
             expect(responseData).toEqual({ error: mockError.message });
+            expect(vi.mocked(logger.error)).toHaveBeenCalledWith('Failed to decode config', {
+                error: 'Invalid config',
+                cause: 'Unsupported config encoding version',
+            });
         });
     });
 });

--- a/packages/api-handlers/src/server/__tests__/encoding.test.ts
+++ b/packages/api-handlers/src/server/__tests__/encoding.test.ts
@@ -3,6 +3,7 @@ import { PageColorType } from '@repo/shared/enums/page-colors';
 import { WheelColorType } from '@repo/shared/enums/wheel-colors';
 import { ConfigFormInputs } from '@repo/shared/types/config';
 import { configFormInputsSchema } from '@repo/shared/validators/config';
+import { logger } from '@sentry/cloudflare';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { encodingApi } from '@/server/encoding.js';
 import { decodeConfig, encodeConfig } from '@/utils/encoding.js';
@@ -16,6 +17,11 @@ vi.mock('@repo/shared/utils/colors', async (importOriginal) => ({
     ...(await importOriginal()),
     isPageColorTypeGradient: vi.fn(),
     getPageGradientTheme: vi.fn(),
+}));
+vi.mock('@sentry/cloudflare', () => ({
+    logger: {
+        error: vi.fn(),
+    },
 }));
 
 describe('encodingApi', () => {
@@ -94,6 +100,9 @@ describe('encodingApi', () => {
 
             expect(response.status).toBe(400);
             expect(responseData).toEqual({ error: mockError.message });
+            expect(vi.mocked(logger.error)).toHaveBeenCalledWith('Failed to encode config', {
+                error: 'Encoding failed',
+            });
         });
     });
 

--- a/packages/api-handlers/src/server/encoding.ts
+++ b/packages/api-handlers/src/server/encoding.ts
@@ -11,6 +11,7 @@ import { DEFAULT_FOREGROUND_COLOR, INVERSE_FOREGROUND_COLOR } from '@repo/shared
 import { WheelColorType } from '@repo/shared/enums/wheel-colors';
 import { getPageGradientTheme, isPageColorTypeGradient } from '@repo/shared/utils/colors';
 import { configFormInputsSchema } from '@repo/shared/validators/config';
+import { logger } from '@sentry/cloudflare';
 import { Hono } from 'hono';
 import { z } from 'zod';
 import { AppEnv } from '@/types.js';
@@ -80,6 +81,9 @@ export const encodingApi = new Hono<AppEnv>()
                 encodedConfig: await encodeConfig(newConfig.serialize()),
             });
         } catch (error) {
+            logger.error('Failed to encode config', {
+                error: (error as Error)?.message,
+            });
             return c.json({ error: (error as Error)?.message ?? 'Error encoding config' }, 400);
         }
     })

--- a/packages/api-handlers/src/server/encoding.ts
+++ b/packages/api-handlers/src/server/encoding.ts
@@ -82,7 +82,7 @@ export const encodingApi = new Hono<AppEnv>()
             });
         } catch (error) {
             logger.error('Failed to encode config', {
-                error: (error as Error)?.message,
+                error: (error as Error)?.message ?? 'Error encoding config',
             });
             return c.json({ error: (error as Error)?.message ?? 'Error encoding config' }, 400);
         }
@@ -103,7 +103,7 @@ export const encodingApi = new Hono<AppEnv>()
         } catch (error) {
             const cause = (error as Error)?.cause;
             logger.error('Failed to decode config', {
-                error: (error as Error)?.message,
+                error: (error as Error)?.message ?? 'Error decoding config',
                 ...(cause instanceof Error ? { cause: cause.message } : {}),
             });
             return c.json({ error: (error as Error)?.message ?? 'Error decoding config' }, 400);

--- a/packages/api-handlers/src/server/encoding.ts
+++ b/packages/api-handlers/src/server/encoding.ts
@@ -101,6 +101,11 @@ export const encodingApi = new Hono<AppEnv>()
         try {
             return c.json(await decodeConfig(encodedConfig));
         } catch (error) {
+            const cause = (error as Error)?.cause;
+            logger.error('Failed to decode config', {
+                error: (error as Error)?.message,
+                ...(cause instanceof Error ? { cause: cause.message } : {}),
+            });
             return c.json({ error: (error as Error)?.message ?? 'Error decoding config' }, 400);
         }
     });

--- a/packages/api-handlers/src/server/index.ts
+++ b/packages/api-handlers/src/server/index.ts
@@ -12,7 +12,7 @@ honoApp.use(
         dsn: 'https://895c486a1e653f07201b20658156b954@o4508580787781632.ingest.us.sentry.io/4509040320970752',
         tracesSampleRate: 1.0,
         enableLogs: true,
-        environment: sentryEnv.APP_ENV,
+        environment: sentryEnv.APP_ENV ?? 'production',
         enabled: sentryEnv.APP_ENV !== 'local',
     }))
 );

--- a/packages/api-handlers/src/server/index.ts
+++ b/packages/api-handlers/src/server/index.ts
@@ -11,6 +11,8 @@ honoApp.use(
     sentry(honoApp, (sentryEnv) => ({
         dsn: 'https://895c486a1e653f07201b20658156b954@o4508580787781632.ingest.us.sentry.io/4509040320970752',
         tracesSampleRate: 1.0,
+        enableLogs: true,
+        environment: sentryEnv.APP_ENV,
         enabled: sentryEnv.APP_ENV !== 'local',
     }))
 );


### PR DESCRIPTION
# Pull Request

## Description

The Sentry Logs tab has always been empty for this project. This turns it on for the Cloudflare Worker and gives it something to report.

**Root cause, and it is not the recent upgrade.** `enableLogs` is a top-level `init` option that defaults to `false` (`@sentry/core@10.70.0`, `types/options.d.ts:530`), and neither `init` call in this repo has ever set it, in either the current or the deprecated `_experiments` form. Sentry's Logs product has therefore received nothing since it shipped. #33 changed no behavior here.

Confirmed against the live Sentry org before writing any code: the `logs` dataset was empty across 90 days for both `wits-api` and `wits-web`, while `spans` flowed normally and current. Logs being the only empty dataset, from the same SDK instance that reports spans fine, is exactly the signature of `enableLogs` being unset.

**Enabling the flag alone would not have fixed it.** It opens the transport; it does not produce logs. The Worker source tree contains zero `console.*` calls, so there was nothing to forward. Something had to emit.

The natural place turned out to be a real gap. Both encoding routes convert a thrown error into a normal 400 JSON response, so the Sentry Hono middleware never observes an exception and the failure produces no issue, no log, and no trace error. Those failures were completely invisible.

Three changes:

1. **`enableLogs: true` and `environment`** on the Worker `sentry()` options.
2. **`logger.error` in both catch blocks**, before the existing 400 return.
3. **Assertions in the two existing error-path tests**, plus negative assertions on the happy paths.

### The `cause` attribute, and why it is not symmetric with encode

`decodeConfig` rethrows every internal failure as `new Error('Invalid config', { cause: error })`, so `(error as Error).message` is the constant string `"Invalid config"` no matter what actually went wrong. A log carrying only that identifies nothing. The decode log therefore also records `cause`, via a conditional spread rather than `String(cause)` — the latter emits the literal string `"undefined"` when an error has no cause. `encodeConfig` does no such wrapping, so its log needs no `cause`.

The live test proved this was worth doing. Two malformed payloads both returned `400 {"error":"Invalid config"}`, and both logs are identical at the message level. Filtering on `cause:"Unsupported config encoding version"` matched exactly one of the two.

## Type of Change

- [x] New feature (non-breaking change that adds functionality)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Additional Context

### A review finding that corrected the design, not the code

Code review caught a defect in the spec's reasoning that the implementation had faithfully inherited. The spec claimed leaving `environment` undefined was "safe either way" because the SDK falls back to `production`. That is true for events and **false for logs**:

- Events get the fallback at `@sentry/core/.../prepareEvent.js:58`.
- Logs never go through `prepareEvent`. The log path sets `sentry.environment` directly from the option (`logs/internal.js:58`) through `setLogAttribute`, guarded by `if (value && ...)` (`internal.js:16-20`). There is no `DEFAULT_ENVIRONMENT` anywhere in the log path.

`APP_ENV` is not set anywhere in `.github/` or `wrangler.jsonc`, so had it also been unset in the Cloudflare dashboard, production logs would have shipped with no environment attribute while spans from the same client reported `production` — silently defeating any `environment:production` alert. A smaller version of the exact problem this PR exists to fix.

Resolved with `environment: sentryEnv.APP_ENV ?? 'production'`, a no-op when a value is supplied, and the wrong reasoning corrected in both the spec and the plan.

Worth confirming the dashboard `APP_ENV` value at some point regardless; the fallback just means it is no longer load-bearing.

### Live verification

Run locally against the real Sentry project with `APP_ENV=development` (`.dev.vars` is gitignored and was reverted afterward):

```bash
curl -X POST localhost:8787/api/config/decode \
  -H 'Content-Type: application/json' \
  -d '{"encodedConfig":"garbage"}'
# 400 {"error":"Invalid config"}
```

The `logs` dataset, empty for 90 days, returned:

```
2026-08-12T04:24:50Z  [ERROR]  Failed to decode config   environment:development
```

Two logs, each correlated to its own trace, with `error` and `cause` attributes both present and queryable. This mattered as a gate: a green suite has coexisted with an empty Logs tab for months, and the unit tests assert against a `vi.fn()`, so they reproduce that same blind spot. Only the live send proves ingestion.

### Expectation setting

A 90 day span query over these two routes returns 12 completed `http.server` spans, all HTTP 200. Neither catch block has fired in production in that window. **This PR will not put anything in the production Logs tab on its own** — the tab stays empty until something genuinely breaks. That is correct behavior for error-level logging, not a sign the change failed.

### Consciously accepted, not fixed

- Up to roughly 10 characters of caller payload can reach the `cause` attribute via a V8 `JSON.parse` SyntaxError. Narrow reachability, structured attribute, no downstream parsing to confuse.
- Both routes are unauthenticated, so log volume is caller-controlled. Sentry spike protection is the proportionate lever if it ever becomes real.
- The cause-absent branch of the conditional spread has no test. It is unreachable through the code under test, since `decodeConfig` always attaches a cause.

### Verification

`test:ci` 200/200 across 18 files (unchanged baseline — this adds assertions, not test cases), `build`, `sherif`, and `lint` all clean. Note that `packages/api-handlers` has no `check-types` script, so the pre-commit hook skips it; `npm run build --workspace packages/api-handlers` was the typecheck gate throughout.

Design spec and implementation plan are included in the branch under `docs/superpowers/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)